### PR TITLE
Add landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { diamondTheme } from "./theme";
 import { DemoPage } from "./routes/DemoPage";
 import { MainPage } from "./routes/MainPage";
 import { EditorPage } from "./routes/EditorPage";
+import { LandingPage } from "./routes/LandingPage";
 
 const INITIAL_SCREEN_STATE = {
   main: {
@@ -26,9 +27,14 @@ function App({}) {
               <Switch>
                 <Route exact path="/demo" component={DemoPage} />
                 <Route exact path="/editor" component={EditorPage} />
-                <Route exact path="/:beamline" component={MainPage} />
-                <Route exact path="/:beamline/:screenId" component={MainPage} />
-                <Route exact path="/" component={MainPage} />
+                <Route exact path="/synoptic" component={MainPage} />
+                <Route exact path="/synoptic/:beamline" component={MainPage} />
+                <Route
+                  exact
+                  path="/synoptic/:beamline/:screenId"
+                  component={MainPage}
+                />
+                <Route exact path="/" component={LandingPage} />
               </Switch>
             </FileProvider>
           </Router>

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -13,6 +13,7 @@ import { Breadcrumbs, Link } from "@mui/material";
 import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
 
 interface AppBarProps extends MuiAppBarProps {
+  fullscreen: number;
   open?: boolean;
 }
 
@@ -24,9 +25,10 @@ const AppBar = styled(MuiAppBar, {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen
   }),
+  width: "100%",
   variants: [
     {
-      props: ({ open }) => open,
+      props: ({ open, fullscreen }) => open && !fullscreen,
       style: {
         marginLeft: DRAWER_WIDTH,
         width: `calc(100% - ${DRAWER_WIDTH}px)`,
@@ -37,7 +39,7 @@ const AppBar = styled(MuiAppBar, {
       }
     },
     {
-      props: ({ open }) => !open,
+      props: ({ open, fullscreen }) => !open && !fullscreen,
       style: {
         marginLeft: `calc(${theme.spacing(7)} + 1px)`,
         width: `calc(100% - ${theme.spacing(7)} - 8px)`
@@ -46,7 +48,8 @@ const AppBar = styled(MuiAppBar, {
   ]
 }));
 
-export default function DLSAppBar() {
+export default function DLSAppBar(props: { fullScreen: boolean }) {
+  const { fullScreen } = props;
   const { state } = useContext(BeamlineTreeStateContext);
   const fileContext = useContext(FileContext);
 
@@ -96,6 +99,7 @@ export default function DLSAppBar() {
       <AppBar
         position="absolute"
         open={state.menuBarOpen}
+        fullscreen={fullScreen ? 1 : 0}
         sx={{ height: APP_BAR_HEIGHT }}
       >
         <Toolbar>

--- a/src/components/BeamlineSelect.tsx
+++ b/src/components/BeamlineSelect.tsx
@@ -43,7 +43,7 @@ export default function BeamlineSelect() {
       fileContext,
       undefined,
       {},
-      `/${event.target.value}`
+      `/synoptic/${event.target.value}`
     );
   };
 

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -1,0 +1,57 @@
+import {
+  Button as MuiButton,
+  Card,
+  CardActions,
+  CardContent,
+  CardProps,
+  styled,
+  Typography
+} from "@mui/material";
+import { useHistory } from "react-router-dom";
+
+const Button = styled(MuiButton)(({ theme }) => ({
+  backgroundColor: theme.palette.info.contrastText,
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: "center",
+  color: theme.palette.info.main
+}));
+
+interface LinkCardProps extends CardProps {
+  info: {
+    name: string;
+    route: string;
+    text: string;
+  };
+}
+
+export default function LinkCard(props: LinkCardProps) {
+  const history = useHistory();
+  const { info } = props;
+
+  const handleLinkClick = (e: any) => {
+    history.push(e.target.value);
+  };
+
+  return (
+    <Card sx={{ height: "100%", width: "100%" }}>
+      <CardContent>
+        <Typography variant="h4" component="div">
+          {info.name}
+        </Typography>
+        <Typography sx={{ color: "text.secondary", fontSize: 14 }}>
+          {info.route}
+        </Typography>
+        <Typography variant="body1" sx={{ whiteSpace: "pre-wrap" }}>
+          <br />
+          {info.text}
+        </Typography>
+      </CardContent>
+      <CardActions>
+        <Button size="medium" value={info.route} onClick={handleLinkClick}>
+          VISIT
+        </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -1,22 +1,12 @@
 import {
-  Button as MuiButton,
   Card,
-  CardActions,
   CardContent,
   CardProps,
-  styled,
-  Typography
+  Typography,
+  CardActionArea,
+  useTheme
 } from "@mui/material";
 import { useHistory } from "react-router-dom";
-
-const Button = styled(MuiButton)(({ theme }) => ({
-  backgroundColor: theme.palette.info.contrastText,
-  ...theme.typography.body2,
-  padding: theme.spacing(1),
-  textAlign: "center",
-  color: theme.palette.info.main
-}));
-
 interface LinkCardProps extends CardProps {
   info: {
     name: string;
@@ -26,32 +16,36 @@ interface LinkCardProps extends CardProps {
 }
 
 export default function LinkCard(props: LinkCardProps) {
+  const theme = useTheme();
   const history = useHistory();
   const { info } = props;
 
-  const handleLinkClick = (e: any) => {
-    history.push(e.target.value);
+  const handleCardClick = (route: string) => {
+    history.push(route);
   };
 
   return (
     <Card sx={{ height: "100%", width: "100%" }}>
-      <CardContent>
-        <Typography variant="h4" component="div">
-          {info.name}
-        </Typography>
-        <Typography sx={{ color: "text.secondary", fontSize: 14 }}>
-          {info.route}
-        </Typography>
-        <Typography variant="body1" sx={{ whiteSpace: "pre-wrap" }}>
-          <br />
-          {info.text}
-        </Typography>
-      </CardContent>
-      <CardActions>
-        <Button size="medium" value={info.route} onClick={handleLinkClick}>
-          VISIT
-        </Button>
-      </CardActions>
+      <CardActionArea onClick={() => handleCardClick(info.route)}>
+        <CardContent>
+          <Typography variant="h4" component="div">
+            {info.name}
+          </Typography>
+          <Typography sx={{ color: "text.secondary", fontSize: 14 }}>
+            {info.route}
+          </Typography>
+          <Typography variant="body1" sx={{ whiteSpace: "pre-wrap" }}>
+            <br />
+            {info.text}
+          </Typography>
+          <Typography
+            sx={{ textAlign: "center", color: theme.palette.info.main }}
+          >
+            <br />
+            VISIT
+          </Typography>
+        </CardContent>
+      </CardActionArea>
     </Card>
   );
 }

--- a/src/components/ScreenDisplay.tsx
+++ b/src/components/ScreenDisplay.tsx
@@ -70,7 +70,7 @@ export default function ScreenDisplay() {
       if (currentPath !== pathname) {
         // URL and state are out of sync with file displayed, update accordingly
         history.replace(
-          `/${state.currentBeamline}/${currentPath}`,
+          `/synoptic/${state.currentBeamline}/${currentPath}`,
           location.state
         );
       }

--- a/src/components/ScreenTreeView.tsx
+++ b/src/components/ScreenTreeView.tsx
@@ -37,7 +37,7 @@ export default function ScreenTreeView() {
       fileContext,
       undefined,
       {},
-      `/${state.currentBeamline}/${itemId}`
+      `/synoptic/${state.currentBeamline}/${itemId}`
     );
   };
 

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -48,7 +48,7 @@ export function LandingPage() {
             Daedalus is a demo web application for EPICS, modelled on Phoebus
             .bob files.
             <br />
-            It comprimises multiple separate demos, including a beamline
+            It comprises multiple separate demos, including a beamline
             synoptic, an editor and a Data Browser.
             <br />
             You can explore the demos below.

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -12,7 +12,7 @@ const CARD_INFO = [
   {
     name: "Synoptic View",
     route: "/synoptic",
-    text: "A demonstration of beamline synoptic views, allowing you to navigate the system of files via in-screen buttons, breadcrumbs or a generated map of the available files.\n\nSelect a beamline from the dropdown to begin navigation."
+    text: "A demonstration of beamline synoptic views, allowing you to navigate the system of files via in-screen buttons, breadcrumbs or a generated map of the available files.\n\nSelect a beamline from the dropdown to begin."
   },
   {
     name: "Editor View",

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,0 +1,79 @@
+import { Box, Grid, Stack, Typography } from "@mui/material";
+import DLSAppBar from "../components/AppBar";
+import { useWindowHeight, APP_BAR_HEIGHT } from "../utils/helper";
+import LinkCard from "../components/LinkCard";
+
+const CARD_INFO = [
+  {
+    name: "Screen Demo",
+    route: "/demo",
+    text: "A page to test out the .bob screen display capabilities of Daedalus.\n\nPass in the URL to a file, add any macros you might need and see how the screen looks rendered with cs-web-lib."
+  },
+  {
+    name: "Synoptic View",
+    route: "/synoptic",
+    text: "A demonstration of beamline synoptic views, allowing you to navigate the system of files via in-screen buttons, breadcrumbs or a generated map of the available files.\n\nSelect a beamline from the dropdown to begin navigation."
+  },
+  {
+    name: "Editor View",
+    route: "/editor",
+    text: "A demonstration of the Daedalus Editor functionality. This will eventually allow editing of .bob files inside the web.\n\nOpen files, view widget properties and drag-and-drop new widgets from the palette."
+  },
+  {
+    name: "Data Browser",
+    route: "/data-browser",
+    text: "A demo recreation of Phoebus' Data Browser, this allows you to view archived PV data plotted against time.\n\nType in the name of a PV, select an archiver and view the plot as it updates with real-time data."
+  }
+];
+
+export function LandingPage() {
+  // get width
+  return (
+    <>
+      <DLSAppBar fullScreen={true} />
+      <Box
+        sx={{
+          display: "flex",
+          width: "100%",
+          height: `calc(${useWindowHeight()}px - ${APP_BAR_HEIGHT}px - 10px)`,
+          margin: `calc(${APP_BAR_HEIGHT}px + 5px) 5px 5px 5px`
+        }}
+      >
+        <Stack sx={{ alignItems: "center" }}>
+          <Typography variant="h1" sx={{ margin: "10px" }}>
+            Welcome to Daedalus!
+          </Typography>
+          <Typography variant="body1" sx={{ textAlign: "center" }}>
+            <br />
+            Daedalus is a demo web application for EPICS, modelled on Phoebus
+            .bob files.
+            <br />
+            It comprimises multiple separate demos, including a beamline
+            synoptic, an editor and a Data Browser.
+            <br />
+            You can explore the demos below.
+          </Typography>
+          <Box
+            sx={{
+              width: "45%",
+              minWidth: "350px",
+              display: "flex",
+              justifyContent: "center",
+              marginTop: "50px"
+            }}
+          >
+            <Grid container spacing={2}>
+              {CARD_INFO.map(card => {
+                return (
+                  <Grid key={card.name} item xs={6}>
+                    <LinkCard info={card} />
+                  </Grid>
+                );
+              })}
+            </Grid>
+          </Box>
+        </Stack>
+      </Box>
+    </>
+  );
+}

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -40,7 +40,7 @@ export function LandingPage() {
         }}
       >
         <Stack sx={{ alignItems: "center" }}>
-          <Typography variant="h1" sx={{ margin: "10px" }}>
+          <Typography variant="h1" sx={{ margin: "10px", textAlign: "center" }}>
             Welcome to Daedalus!
           </Typography>
           <Typography variant="body1" sx={{ textAlign: "center" }}>
@@ -48,30 +48,26 @@ export function LandingPage() {
             Daedalus is a demo web application for EPICS, modelled on Phoebus
             .bob files.
             <br />
-            It comprises multiple separate demos, including a beamline
-            synoptic, an editor and a Data Browser.
+            It comprises multiple separate demos, including a beamline synoptic,
+            an editor and a Data Browser.
             <br />
             You can explore the demos below.
           </Typography>
-          <Box
-            sx={{
-              width: "45%",
-              minWidth: "350px",
-              display: "flex",
-              justifyContent: "center",
-              marginTop: "50px"
-            }}
-          >
-            <Grid container spacing={2}>
-              {CARD_INFO.map(card => {
-                return (
-                  <Grid key={card.name} item xs={6}>
-                    <LinkCard info={card} />
-                  </Grid>
-                );
-              })}
+          <Grid sx={{ marginTop: "3%", width: "85%" }} container>
+            <Grid item md={3} sm={0} />
+            <Grid item md={6} sm={12}>
+              <Grid container spacing={2}>
+                {CARD_INFO.map(card => {
+                  return (
+                    <Grid key={card.name} item xs={12} sm={6}>
+                      <LinkCard info={card} />
+                    </Grid>
+                  );
+                })}
+              </Grid>
             </Grid>
-          </Box>
+            <Grid item md={3} sm={0} />
+          </Grid>
         </Stack>
       </Box>
     </>

--- a/src/routes/MainPage.tsx
+++ b/src/routes/MainPage.tsx
@@ -113,7 +113,7 @@ export function MainPage() {
         <BeamlineTreeStateContext.Provider value={{ state, dispatch }}>
           {state.filesLoaded ? (
             <>
-              <DLSAppBar />
+              <DLSAppBar fullScreen={false} />
               <MiniMenuBar />
               <ScreenDisplay />
             </>

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/src/tests/components/LinkCard.test.tsx
+++ b/src/tests/components/LinkCard.test.tsx
@@ -16,7 +16,7 @@ vi.mock("react-router-dom", async importOriginal => {
 });
 
 describe("LinkCard", (): void => {
-  it("successfully navigates to route on button click", async (): Promise<void> => {
+  it("successfully navigates to route on card click", async (): Promise<void> => {
     const info = {
       name: "Testing",
       route: "/test",
@@ -27,9 +27,9 @@ describe("LinkCard", (): void => {
         <LinkCard info={info} />
       </BrowserRouter>
     );
-    expect(getByText("Testing")).toBeInTheDocument();
-    const button = await getByText("VISIT");
-    await fireEvent.click(button);
+    const card = getByText("Testing");
+    expect(card).toBeInTheDocument();
+    await fireEvent.click(card);
     expect(mockHistoryPush).toHaveBeenCalledExactlyOnceWith("/test");
   });
 });

--- a/src/tests/components/LinkCard.test.tsx
+++ b/src/tests/components/LinkCard.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LinkCard from "../../components/LinkCard";
+import { BrowserRouter } from "react-router-dom";
+
+const mockHistoryPush = vi.fn();
+
+vi.mock("react-router-dom", async importOriginal => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: mockHistoryPush
+    })
+  };
+});
+
+describe("LinkCard", (): void => {
+  it("successfully navigates to route on button click", async (): Promise<void> => {
+    const info = {
+      name: "Testing",
+      route: "/test",
+      text: "A test."
+    };
+    const { getByText } = render(
+      <BrowserRouter>
+        <LinkCard info={info} />
+      </BrowserRouter>
+    );
+    expect(getByText("Testing")).toBeInTheDocument();
+    const button = await getByText("VISIT");
+    await fireEvent.click(button);
+    expect(mockHistoryPush).toHaveBeenCalledExactlyOnceWith("/test");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,8 @@ export default defineConfig(({ command, mode }) => {
     test: {
             environment: 'jsdom',
             include: ['**/*.test.ts', '**/*.test.tsx'],
-            globals: true
+            globals: true,
+            setupFiles: 'src/setupTests.tsx'
         },
   }
 


### PR DESCRIPTION
This PR completes #4 by adding a Landing Page at the root URL. This allows you to navigate to different demo pages via buttons. I've added a Data Browser route despite it not existing yet because it should be added soon, and it was easier to arrange 4 Cards in a grid. 

I've also added a test for the LinkCard component created. I'm unsure whether we should have tests for the top level route components e.g. LandingPage?

I'm open to any suggestions for better descriptive text for the Cards too.