### PR TITLE
Version image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,9 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get latest tag
+        run: echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
       - name: Log in to GitHub Docker Registry
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,6 +2,8 @@ name: Docker Image CI
 
 on:
   push:
+    tags:
+    - '*'
   pull_request:
     branches:
       - main
@@ -20,9 +22,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Get latest tag
-        run: echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Log in to GitHub Docker Registry
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
@@ -52,6 +51,13 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+
+      # Extract the git tag for the checked out commit, or blank string if it does not have one
+      - name: Get commit tag
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        run: |
+          TAG=$(git describe --tags --exact-match || echo "")
+          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
 
       - name: Create tags for publishing image
         id: meta


### PR DESCRIPTION
This improves the image build workflow by adding a version tag based upon the git repo tag of the commit being built.
Tags are only added by builds triggered by a new tag or by a manually triggered build.