### PR TITLE
Add beamlines to config

### DIFF
--- a/public/config/config.json
+++ b/public/config/config.json
@@ -4,6 +4,14 @@
   "PVWS_SSL": true,
   "THROTTLE_PERIOD": 100,
   "beamlines" : {
+    "BLTEST": {
+      "host": "",
+      "entryPoint": "/BOBs/BLTEST/json_map.json"
+    },
+    "BLFAKE": {
+      "host": "",
+      "entryPoint": "/BOBs/BLFAKE/json_map.json"
+    },
     "B23": {
       "host": "http://localhost:8000/",
       "entryPoint": "example-synoptic/b23-services/synoptic/opis/json_map.json"

--- a/public/config/config.json
+++ b/public/config/config.json
@@ -2,5 +2,11 @@
 {
   "PVWS_SOCKET": "pvws.diamond.ac.uk:443",
   "PVWS_SSL": true,
-  "THROTTLE_PERIOD": 100
+  "THROTTLE_PERIOD": 100,
+  "beamlines" : {
+    "B23": {
+      "host": "http://localhost:8000/",
+      "entryPoint": "example-synoptic/b23-services/synoptic/opis/json_map.json"
+    }
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,40 @@
 import { CsWebLibConfig } from "@diamondlightsource/cs-web-lib";
 
-export const loadConfig = async (): Promise<CsWebLibConfig> => {
+export type BeamlinesConfig = {
+  [beamline: string]: {
+    host: string,
+    entryPoint: string,
+  }
+};
+
+export type DaedalusConfig = CsWebLibConfig & {
+  beamlines?: BeamlinesConfig
+}
+
+let config: DaedalusConfig | null = null;
+
+export const loadConfig = async (): Promise<DaedalusConfig> => {
+  if (config) {
+    return config;
+  }
+
   try {
     const response = await fetch('/config/config.json');
-    return await response.json();
-  } catch {
-    console.log("Configuration not found falling back to defaults");
-
-    const emptyConfig: CsWebLibConfig = {
+    config = await response.json();
+  } catch(error) {
+    console.warn("Configuration not found falling back to defaults", error);
+    config = {
       PVWS_SOCKET: undefined,
       PVWS_SSL: undefined,
-      THROTTLE_PERIOD: undefined
+      THROTTLE_PERIOD: undefined,
+      beamlines: {},
     };
-
-    return new Promise((resolve) => { resolve(emptyConfig) });
   }
+
+  return config as DaedalusConfig;;
+}
+
+export const resetConfig = () => {
+  // This is to aid testing.
+  config = null;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,7 @@ export const loadConfig = async (): Promise<DaedalusConfig> => {
     };
   }
 
-  return config as DaedalusConfig;;
+  return config as DaedalusConfig;
 }
 
 export const resetConfig = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,15 +2,12 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { OutlineProvider } from "@diamondlightsource/cs-web-lib";
-import { loadConfig } from "./config.ts";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);
 
-loadConfig().then(config => {
-  root.render(
-    <OutlineProvider>
-      <App config={config} />
-    </OutlineProvider>
-  );
-});
+root.render(
+  <OutlineProvider>
+    <App />
+  </OutlineProvider>
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -240,24 +240,7 @@ export const initialState: BeamlineTreeState = {
   currentScreenId: "",
   currentScreenLabel: "",
   currentScreenFilepath: "",
-  beamlines: {
-    BLTEST: {
-      host: "",
-      entryPoint: "/BOBs/BLTEST/json_map.json",
-      topLevelScreen: "",
-      screenTree: [],
-      filePathIds: {},
-      loaded: false
-    },
-    BLFAKE: {
-      host: "",
-      entryPoint: "/BOBs/BLFAKE/json_map.json",
-      topLevelScreen: "",
-      screenTree: [],
-      filePathIds: {},
-      loaded: false
-    }
-  }
+  beamlines: { }
 };
 
 export function reducer(state: BeamlineTreeState, action: BeamlineAction) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,5 @@
 import { TreeViewBaseItem } from "@mui/x-tree-view";
+import { BeamlinesConfig } from "./config";
 export const LOAD_NEXT_FILE = "loadNextFile";
 export const ADD_FILE = "addFile";
 export const REMOVE_FILE = "removeFile";
@@ -134,13 +135,18 @@ export function demoReducer(state: FileState, action: Action) {
   }
 }
 
-// WIREFRAMING DEMO STORE
+export const APPEND_BEAMLINES = "appendBeamline";
 export const CHANGE_BEAMLINE = "changeBeamline";
 export const CHANGE_SCREEN = "changeScreen";
 export const OPEN_MENU_BAR = "openMenuBar";
 export const LOAD_SCREENS = "loadScreens";
 
 // An interface for our actions
+interface AppendBeamlines {
+  type: typeof APPEND_BEAMLINES;
+  payload: BeamlinesConfig;
+}
+
 interface ChangeBeamline {
   type: typeof CHANGE_BEAMLINE;
   payload: {
@@ -172,7 +178,7 @@ interface LoadScreens {
   };
 }
 
-type BeamlineAction = ChangeBeamline | ChangeScreen | OpenMenuBar | LoadScreens;
+type BeamlineAction = AppendBeamlines | ChangeBeamline | ChangeScreen | OpenMenuBar | LoadScreens;
 
 export type FileIDs = {
   [id: string]: {
@@ -212,6 +218,15 @@ export type BeamlineTreeState = {
   beamlines: BeamlineState;
 };
 
+const defaultBeamline: BeamlineStateProperties = {
+  host: "",
+  entryPoint: "",
+  topLevelScreen: "",
+  screenTree: [],
+  filePathIds: {},
+  loaded: false
+};
+
 // ID here should be the path of the file in whatever
 // filesystem we end up using
 export const initialState: BeamlineTreeState = {
@@ -241,20 +256,23 @@ export const initialState: BeamlineTreeState = {
       screenTree: [],
       filePathIds: {},
       loaded: false
-    },
-    B23: {
-      host: "http://localhost:8000/",
-      entryPoint: "example-synoptic/b23-services/synoptic/opis/json_map.json",
-      topLevelScreen: "",
-      screenTree: [],
-      filePathIds: {},
-      loaded: false
     }
   }
 };
 
 export function reducer(state: BeamlineTreeState, action: BeamlineAction) {
   switch (action.type) {
+    case APPEND_BEAMLINES: {
+      let newBeamlineState = state.beamlines;
+      Object.keys(action.payload).forEach((beamline) => {
+        newBeamlineState = { ...newBeamlineState, [beamline]: { ...defaultBeamline, ...action.payload[beamline] } };
+      });
+
+      return {
+        ...state,
+        beamlines: newBeamlineState,
+      };
+    }
     case CHANGE_BEAMLINE: {
       let newID = state.currentScreenId;
       // Set current screen to top level screen of new beamline

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadConfig, DaedalusConfig, resetConfig } from '../config';
+
+const buildMockConfig = (): DaedalusConfig => ({
+    PVWS_SOCKET: 'ws://pvws.example.org',
+    PVWS_SSL: false,
+    THROTTLE_PERIOD: 100,
+    beamlines: {
+    B23: {
+        host: 'B23.example.org',
+        entryPoint: '/test/path'
+    }
+  }
+});
+
+describe('Configuration Module', () => {
+  const mockFetch = vi.fn();
+  global.fetch = mockFetch;
+
+  describe('loadConfig', () => {
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.resetModules();
+        resetConfig();
+    });
+
+    it('should load configuration from fetch', async () => {
+        const mockConfig: DaedalusConfig = buildMockConfig();
+
+        mockFetch.mockResolvedValueOnce({
+        json: async () => mockConfig
+        });
+
+        const result = await loadConfig();
+
+        expect(mockFetch).toHaveBeenCalledWith('/config/config.json');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(mockConfig);
+    });
+
+    it('should return cached configuration on second call', async () => {
+        const mockConfig = buildMockConfig();
+        
+        mockFetch.mockResolvedValueOnce({
+        json: async () => mockConfig
+        });
+        
+        const result1 = await loadConfig();
+        const result2 = await loadConfig();
+        
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(result1).toEqual(mockConfig);
+        expect(result2).toEqual(mockConfig);
+        expect(result1).toBe(result2);
+    });
+
+    it('should use default configuration on fail to get config file', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
+        
+        const result = await loadConfig();
+        
+        expect(mockFetch).toHaveBeenCalledWith('/config/config.json');
+        expect(result).toEqual({
+        PVWS_SOCKET: undefined,
+        PVWS_SSL: undefined,
+        THROTTLE_PERIOD: undefined,
+        beamlines: {}
+        });
+    });
+
+    it('should use default configuration on JSON parsing error', async () => {
+        mockFetch.mockResolvedValueOnce({
+        json: async () => { throw new Error('Invalid JSON'); }
+        });
+        
+        const result = await loadConfig();
+        
+        expect(result).toEqual({
+        PVWS_SOCKET: undefined,
+        PVWS_SSL: undefined,
+        THROTTLE_PERIOD: undefined,
+        beamlines: {}
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR:
- Adds beamlines to the configuration file
- Adds a reducer action to add the beamlines to the store.
- Loads the config file before App render as part of the react flow, rather than as part of the main JavaScript.
- Displays a loading spinner as the config loads