### PR TITLE
Fix nginx routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN npm run build:nolint
 # Create image for deployment
 FROM nginxinc/nginx-unprivileged:stable AS deployment
 
+COPY nginx.conf /etc/nginx/nginx.conf
 ARG DOCROOT=/usr/share/nginx/html
 COPY --from=build /app/dist ${DOCROOT}
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,6 @@
-http {
+pid /tmp/nginx.pid;
 
+http {
   include mime.types;
 
   set_real_ip_from        0.0.0.0/0;
@@ -8,7 +9,7 @@ http {
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     root /proxy;
     limit_req zone=mylimit burst=70 nodelay;
@@ -16,7 +17,7 @@ http {
     location / {
             root   /usr/share/nginx/html;
             index  index.html index.htm;
-            try_files $uri /index.html;   
+            try_files $uri $uri/ /index.html;   
         }
 
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
This fixes the issues with nginx and Reacts client-side routing. Previously our `nginx.conf` file was not included as part of the Dockerfile, I've now added this in which allows our config to be applied. The [nginx-unprivileged Dockerhub page](https://hub.docker.com/r/nginxinc/nginx-unprivileged) details some of the changes (port 8080, setting pid to allow passing custom `nginx.conf` file)