### PR TITLE
Prevent re-render on screen not in JsonMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daedalus",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@diamondlightsource/cs-web-lib": "^0.9.7",
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ScreenDisplay.tsx
+++ b/src/components/ScreenDisplay.tsx
@@ -70,8 +70,9 @@ export default function ScreenDisplay() {
       const currentFile = Object.values(allFiles).find(
         values => values.file === displayedPath
       );
-      if (currentFile?.urlId !== pathname) {
-        // URL and state are out of sync with file displayed, update accordingly
+
+      if (currentFile?.urlId && currentFile.urlId !== pathname) {
+        // URL and state are out of sync with file displayed, update accordingly, if currentFile is null this file is not in the JsonMap
         navigate(`/synoptic/${state.currentBeamline}/${currentFile?.urlId}`, {
           state: location.state,
           replace: true


### PR DESCRIPTION
This prevents an infinite re-render when the screen is not in the JsonMap.