### PR TITLE
Creating an action to automatically tag main branch with semver

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,7 +57,7 @@ jobs:
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
           TAG=$(git describe --tags --exact-match || echo "")
-          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+          echo "LATEST_TAG=$TAG" >> $GITHUB_ENV
 
       - name: Create tags for publishing image
         id: meta

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -1,0 +1,64 @@
+name: Auto Tag with SemVer
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  tag-main:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+          
+      - name: Get latest semver tag
+        id: get_latest_tag
+        run: |
+          # Get all tags and filter for valid semver tags (vX.Y.Z format)
+          LATEST_TAG=$(git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)
+          
+          # If no valid semver tags exist, start with 0.0.0
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No semantic versioning tags found in the repository. Please create an initial tag (e.g., 0.0.0) manually."
+            exit 1
+          fi
+          
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          
+          # Extract the version numbers
+          VERSION=${LATEST_TAG}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+          
+          # Increment patch version
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+          
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Create new tag
+        id: create_tag
+        run: |
+          NEW_TAG="v${{ steps.get_latest_tag.outputs.new_version }}"
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a $NEW_TAG -m "Auto-incremented patch version"
+      
+      - name: Push tag
+        run: |
+          git push origin ${{ steps.create_tag.outputs.new_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - automatic_semver_tag_action
   workflow_dispatch:
 jobs:
   tag-main:

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - automatic_semver_tag_action
   workflow_dispatch:
 jobs:
   tag-main:

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Create new tag
         id: create_tag
         run: |
-          NEW_TAG="v${{ steps.get_latest_tag.outputs.new_version }}"
+          NEW_TAG="${{ steps.get_latest_tag.outputs.new_version }}"
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
           
           git config --local user.email "action@github.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daedalus",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@diamondlightsource/cs-web-lib": "^0.9.8",
         "@emotion/react": "^11.11.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "daedalus",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
-        "@diamondlightsource/cs-web-lib": "^0.9.7",
+        "@diamondlightsource/cs-web-lib": "^0.9.8",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.17",
@@ -570,9 +570,9 @@
       }
     },
     "node_modules/@diamondlightsource/cs-web-lib": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@diamondlightsource/cs-web-lib/-/cs-web-lib-0.9.7.tgz",
-      "integrity": "sha512-/L1QdLbYRDQYhRMThkIKDy5++EdRmG98uDd6JU2MVQ4IaLUxaMprsCC4wwJY/jnsTEI/97119baT0SQycJYehQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@diamondlightsource/cs-web-lib/-/cs-web-lib-0.9.8.tgz",
+      "integrity": "sha512-DrYegkbvX+jsTU9WFE9RG0u4esGSEueoLgX0iWiediSIR0RpMf/X99Dbr28T3mGVVmXbyD73T93rHYGBq2fMuQ==",
       "license": "ISC",
       "dependencies": {
         "apollo-link-retry": "^2.2.16",
@@ -9472,12 +9472,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -15,7 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@diamondlightsource/cs-web-lib": "^0.9.7",
+    "@diamondlightsource/cs-web-lib": "^0.9.8",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
New action that triggers on push to main.
- Finds current highest semver tag
- Increments the patch version on the tag
- tags the repo with the new semver tag

New tags will trigger the image build action and create a new versioned image.
Also updated:
- Version of cs-web-lib to 0.9.8
- Bump version number to 0.0.6 then to 0.0.7 after test build.