### PR TITLE
Add JsonMap macros on navigation between screens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,18 +19,7 @@ COPY *.json ./
 RUN npm run build:nolint
 
 # Create image for deployment
-FROM nginxinc/nginx-unprivileged:stable AS deployment
-
-
-# Update package lists and upgrade libpng1.6 (libpng16-16 runtime)
-# to fix a security vulnerability (CVE-2025-64720)
-USER root
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends libpng16-16=1.6.39-2+deb12u1; \
-    rm -rf /var/lib/apt/lists/*
+FROM nginxinc/nginx-unprivileged:1.29-alpine AS deployment
 
 USER nginx
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/src/components/BeamlineSelect.tsx
+++ b/src/components/BeamlineSelect.tsx
@@ -3,11 +3,11 @@ import { MenuItem as MuiMenuItem, styled } from "@mui/material";
 import FormControl from "@mui/material/FormControl";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import { useContext } from "react";
-import { FileContext, executeAction } from "@diamondlightsource/cs-web-lib";
-import { CHANGE_BEAMLINE, MacroMap } from "../store";
+import { FileContext } from "@diamondlightsource/cs-web-lib";
+import { CHANGE_BEAMLINE } from "../store";
 import { Tooltip } from "@mui/material";
 import { BeamlineTreeStateContext } from "../App";
-import { buildUrl } from "../utils/urlUtils";
+import { executeOpenPageActionWithFileGuid } from "../utils/csWebLibActions";
 
 const MenuItem = styled(MuiMenuItem)({
   "&.Mui-disabled": {
@@ -27,35 +27,11 @@ export default function BeamlineSelect() {
 
     const beamlineState = state.beamlines[event.target.value];
 
-    const fileMetadata =
-      beamlineState.filePathIds[beamlineState.topLevelScreen];
-
-    const newScreen = buildUrl(
-      beamlineState.host,
-      beamlineState.topLevelScreen
-    );
-
-    const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
-    
-    // Load the toplevel screen for the beamline on click
-    executeAction(
-      {
-        type: "OPEN_PAGE",
-        dynamicInfo: {
-          name: newScreen,
-          location: "main",
-          description: undefined,
-          file: {
-            path: newScreen,
-            macros: macros,
-            defaultProtocol: "ca"
-          }
-        }
-      },
-      fileContext,
-      undefined,
-      {},
-      `/synoptic/${event.target.value}`
+    executeOpenPageActionWithFileGuid(
+      beamlineState,
+      beamlineState.topLevelScreen,
+      event.target.value,
+      fileContext
     );
   };
 

--- a/src/components/BeamlineSelect.tsx
+++ b/src/components/BeamlineSelect.tsx
@@ -4,7 +4,7 @@ import FormControl from "@mui/material/FormControl";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import { useContext } from "react";
 import { FileContext, executeAction } from "@diamondlightsource/cs-web-lib";
-import { CHANGE_BEAMLINE } from "../store";
+import { CHANGE_BEAMLINE, MacroMap } from "../store";
 import { Tooltip } from "@mui/material";
 import { BeamlineTreeStateContext } from "../App";
 import { buildUrl } from "../utils/urlUtils";
@@ -24,20 +24,30 @@ export default function BeamlineSelect() {
       type: CHANGE_BEAMLINE,
       payload: { beamline: event.target.value }
     });
+
+    const beamlineState = state.beamlines[event.target.value];
+
+    const fileMetadata =
+      beamlineState.filePathIds[beamlineState.topLevelScreen];
+
+    const newScreen = buildUrl(
+      beamlineState.host,
+      beamlineState.topLevelScreen
+    );
+
+    const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
+    
     // Load the toplevel screen for the beamline on click
     executeAction(
       {
         type: "OPEN_PAGE",
         dynamicInfo: {
-          name: state.beamlines[event.target.value].topLevelScreen,
+          name: newScreen,
           location: "main",
           description: undefined,
           file: {
-            path: buildUrl(
-              state.beamlines[event.target.value].host,
-              state.beamlines[event.target.value].topLevelScreen
-            ),
-            macros: {},
+            path: newScreen,
+            macros: macros,
             defaultProtocol: "ca"
           }
         }

--- a/src/components/ScreenTreeView.tsx
+++ b/src/components/ScreenTreeView.tsx
@@ -5,6 +5,7 @@ import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
 import { BeamlineTreeStateContext } from "../App";
 import { MenuContext } from "../routes/MainPage";
 import { buildUrl } from "../utils/urlUtils";
+import { MacroMap } from "../store";
 
 export default function ScreenTreeView() {
   const { state } = useContext(BeamlineTreeStateContext);
@@ -17,12 +18,17 @@ export default function ScreenTreeView() {
   };
 
   const handleClick = (itemId: string) => {
+    const beamlineState = state.beamlines[state.currentBeamline]
+
     const fileMetadata =
-      state.beamlines[state.currentBeamline].filePathIds[itemId];
+      beamlineState.filePathIds[itemId];
+
     const newScreen = buildUrl(
-      state.beamlines[state.currentBeamline].host,
-      fileMetadata.file
+      beamlineState.host,
+      fileMetadata?.file ?? beamlineState.topLevelScreen
     );
+
+    const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
 
     executeAction(
       {
@@ -33,7 +39,7 @@ export default function ScreenTreeView() {
           description: undefined,
           file: {
             path: newScreen,
-            macros: {},
+            macros: macros,
             defaultProtocol: "ca"
           }
         }

--- a/src/components/ScreenTreeView.tsx
+++ b/src/components/ScreenTreeView.tsx
@@ -1,11 +1,10 @@
 import { RichTreeView } from "@mui/x-tree-view/RichTreeView";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { TreeViewBaseItem, TreeViewItemId } from "@mui/x-tree-view";
-import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
+import { FileContext } from "@diamondlightsource/cs-web-lib";
 import { BeamlineTreeStateContext } from "../App";
 import { MenuContext } from "../routes/MainPage";
-import { buildUrl } from "../utils/urlUtils";
-import { MacroMap } from "../store";
+import { executeOpenPageActionWithFileGuid } from "../utils/csWebLibActions";
 
 export default function ScreenTreeView() {
   const { state } = useContext(BeamlineTreeStateContext);
@@ -18,36 +17,14 @@ export default function ScreenTreeView() {
   };
 
   const handleClick = (itemId: string) => {
-    const beamlineState = state.beamlines[state.currentBeamline]
+    const selectedBeamlineId = state.currentBeamline;
+    const beamlineState = state.beamlines[selectedBeamlineId];
 
-    const fileMetadata =
-      beamlineState.filePathIds[itemId];
-
-    const newScreen = buildUrl(
-      beamlineState.host,
-      fileMetadata?.file ?? beamlineState.topLevelScreen
-    );
-
-    const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
-
-    executeAction(
-      {
-        type: "OPEN_PAGE",
-        dynamicInfo: {
-          name: newScreen,
-          location: "main",
-          description: undefined,
-          file: {
-            path: newScreen,
-            macros: macros,
-            defaultProtocol: "ca"
-          }
-        }
-      },
-      fileContext,
-      undefined,
-      {},
-      `/synoptic/${state.currentBeamline}/${state.beamlines[state.currentBeamline].filePathIds[itemId].urlId}`
+    executeOpenPageActionWithFileGuid(
+      beamlineState,
+      itemId,
+      selectedBeamlineId,
+      fileContext
     );
   };
 

--- a/src/components/SynopticBreadcrumbs.tsx
+++ b/src/components/SynopticBreadcrumbs.tsx
@@ -2,10 +2,10 @@ import Typography from "@mui/material/Typography";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { ReactNode, useContext } from "react";
 import { Breadcrumbs, Link } from "@mui/material";
-import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
-import { BeamlineStateProperties, MacroMap } from "../store";
+import { FileContext } from "@diamondlightsource/cs-web-lib";
+import { BeamlineStateProperties } from "../store";
 import { BeamlineTreeStateContext } from "../App";
-import { buildUrl } from "../utils/urlUtils";
+import { executeOpenPageActionWithUrlId } from "../utils/csWebLibActions";
 
 export const SynopticBreadcrumbs = () => {
   const { state } = useContext(BeamlineTreeStateContext);
@@ -18,7 +18,11 @@ export const SynopticBreadcrumbs = () => {
 
   return (
     <Breadcrumbs
-      onClick={handleClick(state.beamlines[state.currentBeamline], fileContext)}
+      onClick={handleClick(
+        state.currentBeamline,
+        state.beamlines[state.currentBeamline],
+        fileContext
+      )}
       separator={<NavigateNextIcon fontSize="small" />}
       aria-label="breadcrumb"
       sx={{
@@ -37,7 +41,11 @@ export const SynopticBreadcrumbs = () => {
 };
 
 const handleClick =
-  (beamlineState: BeamlineStateProperties, fileContext: any) =>
+  (
+    selectedBeamlineId: string,
+    beamlineState: BeamlineStateProperties,
+    fileContext: any
+  ) =>
   (event: any) => {
     if (event.target.pathname) {
       event.preventDefault();
@@ -45,34 +53,11 @@ const handleClick =
         .split("/")
         .at(-1) as string;
 
-      const fileMetadata = Object.values(beamlineState.filePathIds).find(
-        x => x.urlId === urlId
-      );
-
-      const newScreen = buildUrl(
-        beamlineState.host,
-        fileMetadata?.file);
-
-      const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
-
-      executeAction(
-        {
-          type: "OPEN_PAGE",
-          dynamicInfo: {
-            name: newScreen,
-            location: "main",
-            description: undefined,
-            file: {
-              path: newScreen,
-              macros: macros,
-              defaultProtocol: "ca"
-            }
-          }
-        },
-        fileContext,
-        undefined,
-        {},
-        event.target.pathname
+      executeOpenPageActionWithUrlId(
+        beamlineState,
+        urlId,
+        selectedBeamlineId,
+        fileContext
       );
     }
   };

--- a/src/components/SynopticBreadcrumbs.tsx
+++ b/src/components/SynopticBreadcrumbs.tsx
@@ -3,7 +3,7 @@ import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { ReactNode, useContext } from "react";
 import { Breadcrumbs, Link } from "@mui/material";
 import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
-import { BeamlineStateProperties } from "../store";
+import { BeamlineStateProperties, MacroMap } from "../store";
 import { BeamlineTreeStateContext } from "../App";
 import { buildUrl } from "../utils/urlUtils";
 
@@ -37,7 +37,7 @@ export const SynopticBreadcrumbs = () => {
 };
 
 const handleClick =
-  (currentBeamlineState: BeamlineStateProperties, fileContext: any) =>
+  (beamlineState: BeamlineStateProperties, fileContext: any) =>
   (event: any) => {
     if (event.target.pathname) {
       event.preventDefault();
@@ -45,10 +45,15 @@ const handleClick =
         .split("/")
         .at(-1) as string;
 
-      const fileMetadata = Object.values(currentBeamlineState.filePathIds).find(
+      const fileMetadata = Object.values(beamlineState.filePathIds).find(
         x => x.urlId === urlId
       );
-      const newScreen = buildUrl(currentBeamlineState.host, fileMetadata?.file);
+
+      const newScreen = buildUrl(
+        beamlineState.host,
+        fileMetadata?.file);
+
+      const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
 
       executeAction(
         {
@@ -59,7 +64,7 @@ const handleClick =
             description: undefined,
             file: {
               path: newScreen,
-              macros: {},
+              macros: macros,
               defaultProtocol: "ca"
             }
           }

--- a/src/routes/EditorPage.tsx
+++ b/src/routes/EditorPage.tsx
@@ -5,6 +5,7 @@ import {
   CHANGE_SCREEN,
   initialState,
   LOAD_SCREENS,
+  MacroMap,
   reducer
 } from "../store";
 import { parseScreenTree } from "../utils/parser";
@@ -59,12 +60,20 @@ export function EditorPage() {
         loadScreen: params.screenUrlId
       }
     });
-    if (params.beamline) {
+    if (params.beamline && params.screenUrlId) {
       // If we navigated directly to a beamline and/or screen, load in display
-      const newBeamlineState = newBeamlines[params.beamline];
-      const newScreen = params.screenUrlId
-        ? newBeamlineState.filePathIds[params.screenUrlId].file
-        : buildUrl(newBeamlineState.host, newBeamlineState.topLevelScreen);
+      const beamlineState = newBeamlines[params.beamline];
+
+      const fileMetadata =
+          beamlineState.filePathIds[params.screenUrlId];
+
+      const newScreen = buildUrl(
+        beamlineState.host,
+        fileMetadata?.file ?? beamlineState.topLevelScreen
+      );
+
+      const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
+
       executeAction(
         {
           type: "OPEN_PAGE",
@@ -74,7 +83,7 @@ export function EditorPage() {
             description: undefined,
             file: {
               path: newScreen,
-              macros: {},
+              macros: macros,
               defaultProtocol: "ca"
             }
           }

--- a/src/routes/EditorPage.tsx
+++ b/src/routes/EditorPage.tsx
@@ -5,14 +5,13 @@ import {
   CHANGE_SCREEN,
   initialState,
   LOAD_SCREENS,
-  MacroMap,
   reducer
 } from "../store";
 import { parseScreenTree } from "../utils/parser";
-import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
+import { FileContext } from "@diamondlightsource/cs-web-lib";
 import Editor from "../components/Editor";
 import { useParams } from "react-router-dom";
-import { buildUrl } from "../utils/urlUtils";
+import { executeOpenPageActionWithUrlId } from "../utils/csWebLibActions";
 
 /**
  * Displays a mock editor page with palette and Phoebus
@@ -63,34 +62,11 @@ export function EditorPage() {
     if (params.beamline && params.screenUrlId) {
       // If we navigated directly to a beamline and/or screen, load in display
       const beamlineState = newBeamlines[params.beamline];
-
-      const fileMetadata =
-          beamlineState.filePathIds[params.screenUrlId];
-
-      const newScreen = buildUrl(
-        beamlineState.host,
-        fileMetadata?.file ?? beamlineState.topLevelScreen
-      );
-
-      const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
-
-      executeAction(
-        {
-          type: "OPEN_PAGE",
-          dynamicInfo: {
-            name: newScreen,
-            location: "main",
-            description: undefined,
-            file: {
-              path: newScreen,
-              macros: macros,
-              defaultProtocol: "ca"
-            }
-          }
-        },
-        fileContext,
-        undefined,
-        {}
+      executeOpenPageActionWithUrlId(
+        beamlineState,
+        params.screenUrlId,
+        params.beamline,
+        fileContext
       );
     }
   }, []);

--- a/src/routes/MainPage.tsx
+++ b/src/routes/MainPage.tsx
@@ -7,16 +7,17 @@ import {
   useEffect,
   useState
 } from "react";
-import { CHANGE_BEAMLINE, CHANGE_SCREEN, LOAD_SCREENS, MacroMap } from "../store";
+import { CHANGE_BEAMLINE, CHANGE_SCREEN, LOAD_SCREENS } from "../store";
 import DLSAppBar from "../components/AppBar";
 import ScreenDisplay from "../components/ScreenDisplay";
 import { parseScreenTree } from "../utils/parser";
-import { executeAction, FileContext } from "@diamondlightsource/cs-web-lib";
+import { FileContext } from "@diamondlightsource/cs-web-lib";
 import { RotatingLines } from "react-loader-spinner";
 import { SynopticBreadcrumbs } from "../components/SynopticBreadcrumbs";
 import { BeamlineTreeStateContext } from "../App";
 import { useParams } from "react-router-dom";
 import { buildUrl } from "../utils/urlUtils";
+import { executeOpenPageActionWithUrlId } from "../utils/csWebLibActions";
 
 export const MenuContext = createContext<{
   menuOpen: boolean;
@@ -80,34 +81,11 @@ export function MainPage() {
       // If we navigated directly to a beamline and/or screen, load in display
       const newBeamlineState = newBeamlines[params.beamline];
 
-      const fileMetadata = Object.values(newBeamlineState.filePathIds).find(
-        x => x.urlId === params.screenUrlId
-      );
-
-      const newScreen = buildUrl(
-        newBeamlineState.host,
-        fileMetadata?.file ?? newBeamlineState.topLevelScreen
-      );
-
-      const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
-
-      executeAction(
-        {
-          type: "OPEN_PAGE",
-          dynamicInfo: {
-            name: newScreen,
-            location: "main",
-            description: undefined,
-            file: {
-              path: newScreen,
-              macros: macros,
-              defaultProtocol: "ca"
-            }
-          }
-        },
-        fileContext,
-        undefined,
-        {}
+      executeOpenPageActionWithUrlId(
+        newBeamlineState,
+        params.screenUrlId,
+        params.beamline,
+        fileContext
       );
     }
   }, []);

--- a/src/routes/MainPage.tsx
+++ b/src/routes/MainPage.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   useState
 } from "react";
-import { CHANGE_BEAMLINE, CHANGE_SCREEN, LOAD_SCREENS } from "../store";
+import { CHANGE_BEAMLINE, CHANGE_SCREEN, LOAD_SCREENS, MacroMap } from "../store";
 import DLSAppBar from "../components/AppBar";
 import ScreenDisplay from "../components/ScreenDisplay";
 import { parseScreenTree } from "../utils/parser";
@@ -79,14 +79,17 @@ export function MainPage() {
     if (params.beamline) {
       // If we navigated directly to a beamline and/or screen, load in display
       const newBeamlineState = newBeamlines[params.beamline];
-      const filepath = Object.values(newBeamlineState.filePathIds).find(
+
+      const fileMetadata = Object.values(newBeamlineState.filePathIds).find(
         x => x.urlId === params.screenUrlId
-      )?.file;
+      );
 
       const newScreen = buildUrl(
         newBeamlineState.host,
-        filepath ?? newBeamlineState.topLevelScreen
+        fileMetadata?.file ?? newBeamlineState.topLevelScreen
       );
+
+      const macros: MacroMap = fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ?? {};
 
       executeAction(
         {
@@ -97,7 +100,7 @@ export function MainPage() {
             description: undefined,
             file: {
               path: newScreen,
-              macros: {},
+              macros: macros,
               defaultProtocol: "ca"
             }
           }

--- a/src/tests/utils/csWebLibActions.test.ts
+++ b/src/tests/utils/csWebLibActions.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  executeOpenPageActionWithFileGuid,
+  executeOpenPageActionWithUrlId,
+  executeOpenPageAction
+} from "../../utils/csWebLibActions";
+import { executeAction } from "@diamondlightsource/cs-web-lib";
+import * as urlUtils from "../../utils/urlUtils";
+import { BeamlineStateProperties, FileMetadata } from "../../store";
+
+vi.mock("@diamondlightsource/cs-web-lib", () => ({
+  executeAction: vi.fn()
+}));
+
+const buildUrlSpy = vi
+  .spyOn(urlUtils, "buildUrl")
+  .mockImplementation((host, file) => `${host}/${file}`);
+
+describe("executeAction: OPEN_PAGE", () => {
+  let mockBeamlineState: BeamlineStateProperties;
+  let mockFileContext: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockBeamlineState = {
+      host: "http://example.com",
+      topLevelScreen: "default-screen",
+      filePathIds: {
+        "guid-1": {
+          file: "screen1.opi",
+          urlId: "screen1",
+          macros: [{ key1: "value1" }, { key2: "value2" }]
+        },
+        "guid-2": {
+          file: "screen2.opi",
+          urlId: "screen2",
+          macros: [{ key3: "value3" }]
+        },
+        "guid-3": {
+          file: "index.opi",
+          urlId: "index",
+          macros: []
+        }
+      }
+    } as Partial<BeamlineStateProperties> as BeamlineStateProperties;
+
+    mockFileContext = { someContext: "value" };
+  });
+
+  describe("executeOpenPageActionWithFileGuid", () => {
+    it("should call executeOpenPageAction with the correct file metadata based on guid", () => {
+      const fileGuid = "guid-1";
+      const selectedBeamlineId = "beamline-1";
+      const expectedFileMetadata = mockBeamlineState.filePathIds[fileGuid];
+
+      executeOpenPageActionWithFileGuid(
+        mockBeamlineState,
+        fileGuid,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        mockBeamlineState.host,
+        expectedFileMetadata.file
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "OPEN_PAGE",
+          dynamicInfo: expect.objectContaining({
+            file: expect.objectContaining({
+              macros: { key1: "value1", key2: "value2" }
+            })
+          })
+        }),
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}/screen1`
+      );
+    });
+  });
+
+  describe("executeOpenPageActionWithUrlId", () => {
+    it("should find file metadata by urlId and call executeOpenPageAction", () => {
+      const urlId = "screen2";
+      const selectedBeamlineId = "beamline-1";
+      const expectedFileMetadata = mockBeamlineState.filePathIds["guid-2"];
+
+      executeOpenPageActionWithUrlId(
+        mockBeamlineState,
+        urlId,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        mockBeamlineState.host,
+        expectedFileMetadata.file
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "OPEN_PAGE",
+          dynamicInfo: expect.objectContaining({
+            file: expect.objectContaining({
+              macros: { key3: "value3" }
+            })
+          })
+        }),
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}/screen2`
+      );
+    });
+
+    it('should default to "index" when urlId is undefined', () => {
+      const urlId = undefined;
+      const selectedBeamlineId = "beamline-1";
+      const expectedFileMetadata = mockBeamlineState.filePathIds["guid-3"]; // The one with urlId 'index'
+
+      executeOpenPageActionWithUrlId(
+        mockBeamlineState,
+        urlId,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        mockBeamlineState.host,
+        expectedFileMetadata.file
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.anything(),
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}/index`
+      );
+    });
+
+    it("should handle when no matching file metadata is found", () => {
+      const urlId = "non-existent";
+      const selectedBeamlineId = "beamline-1";
+
+      executeOpenPageActionWithUrlId(
+        mockBeamlineState,
+        urlId,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        mockBeamlineState.host,
+        mockBeamlineState.topLevelScreen
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "OPEN_PAGE",
+          dynamicInfo: expect.objectContaining({
+            file: expect.objectContaining({
+              macros: {}
+            })
+          })
+        }),
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}`
+      );
+    });
+  });
+
+  describe("executeOpenPageAction", () => {
+    it("should call executeAction with correct parameters including macros when fileMetadata is provided", () => {
+      const fileMetadata: FileMetadata = {
+        file: "test-screen.opi",
+        urlId: "test-screen",
+        macros: [{ param1: "value1" }, { param2: "value2", param3: "value3" }]
+      };
+      const selectedBeamlineId = "beamline-1";
+      const expectedUrl = `${mockBeamlineState.host}/${fileMetadata.file}`;
+
+      executeOpenPageAction(
+        mockBeamlineState,
+        fileMetadata,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        mockBeamlineState.host,
+        fileMetadata.file
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        {
+          type: "OPEN_PAGE",
+          dynamicInfo: {
+            name: expectedUrl,
+            location: "main",
+            description: undefined,
+            file: {
+              path: expectedUrl,
+              macros: { param1: "value1", param2: "value2", param3: "value3" },
+              defaultProtocol: "ca"
+            }
+          }
+        },
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}/test-screen`
+      );
+    });
+
+    it("should use topLevelScreen when fileMetadata is undefined", () => {
+      const fileMetadata = undefined;
+      const selectedBeamlineId = "beamline-1";
+      const expectedUrl = `${mockBeamlineState.host}/${mockBeamlineState.topLevelScreen}`;
+
+      executeOpenPageAction(
+        mockBeamlineState,
+        fileMetadata,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        mockBeamlineState.host,
+        mockBeamlineState.topLevelScreen
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        {
+          type: "OPEN_PAGE",
+          dynamicInfo: {
+            name: expectedUrl,
+            location: "main",
+            description: undefined,
+            file: {
+              path: expectedUrl,
+              macros: {},
+              defaultProtocol: "ca"
+            }
+          }
+        },
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}`
+      );
+    });
+
+    it("should handle empty macros array", () => {
+      const fileMetadata = {
+        file: "test-screen.opi",
+        urlId: "test-screen",
+        macros: []
+      };
+      const selectedBeamlineId = "beamline-1";
+
+      executeOpenPageAction(
+        mockBeamlineState,
+        fileMetadata,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dynamicInfo: expect.objectContaining({
+            file: expect.objectContaining({
+              macros: {}
+            })
+          })
+        }),
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}/test-screen`
+      );
+    });
+
+    it("should handle undefined macros", () => {
+      const fileMetadata = {
+        file: "test-screen.opi",
+        urlId: "test-screen"
+      };
+      const selectedBeamlineId = "beamline-1";
+
+      executeOpenPageAction(
+        mockBeamlineState,
+        fileMetadata,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dynamicInfo: expect.objectContaining({
+            file: expect.objectContaining({
+              macros: {}
+            })
+          })
+        }),
+        mockFileContext,
+        undefined,
+        {},
+        `/synoptic/${selectedBeamlineId}/test-screen`
+      );
+    });
+
+    it("should use beamlineUrlId when fileMetadata.urlId is undefined", () => {
+      const fileMetadata: FileMetadata = {
+        file: "test-screen.opi",
+        macros: [],
+        urlId: undefined
+      };
+      const selectedBeamlineId = "beamline-1";
+      const expectedUrlPath = `/synoptic/${selectedBeamlineId}`;
+
+      executeOpenPageAction(
+        mockBeamlineState,
+        fileMetadata,
+        selectedBeamlineId,
+        mockFileContext
+      );
+
+      expect(executeAction).toHaveBeenCalledWith(
+        expect.anything(),
+        mockFileContext,
+        undefined,
+        {},
+        expectedUrlPath
+      );
+    });
+  });
+});

--- a/src/utils/csWebLibActions.ts
+++ b/src/utils/csWebLibActions.ts
@@ -1,0 +1,77 @@
+import { executeAction } from "@diamondlightsource/cs-web-lib";
+import { BeamlineStateProperties, FileMetadata, MacroMap } from "../store";
+import { buildUrl } from "./urlUtils";
+
+export const executeOpenPageActionWithFileGuid = (
+  beamlineState: BeamlineStateProperties,
+  fileGuid: string,
+  selectedBeamlineId: string,
+  fileContext: any
+) => {
+  const fileMetadata = beamlineState.filePathIds[fileGuid];
+  executeOpenPageAction(
+    beamlineState,
+    fileMetadata,
+    selectedBeamlineId,
+    fileContext
+  );
+};
+
+export const executeOpenPageActionWithUrlId = (
+  beamlineState: BeamlineStateProperties,
+  urlId: string | undefined,
+  selectedBeamlineId: string,
+  fileContext: any
+) => {
+  const fileMetadata = Object.values(beamlineState.filePathIds).find(
+    x => x.urlId === (urlId ?? "index")
+  );
+
+  executeOpenPageAction(
+    beamlineState,
+    fileMetadata,
+    selectedBeamlineId,
+    fileContext
+  );
+};
+
+export const executeOpenPageAction = (
+  beamlineState: BeamlineStateProperties,
+  fileMetadata: FileMetadata | undefined,
+  selectedBeamlineId: string,
+  fileContext: any
+) => {
+  const newScreen = buildUrl(
+    beamlineState.host,
+    fileMetadata?.file ?? beamlineState.topLevelScreen
+  );
+
+  const macros: MacroMap =
+    fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ??
+    {};
+  const beamlineUrlId = `/synoptic/${selectedBeamlineId}`;
+
+  const urlPath = fileMetadata?.urlId
+    ? `${beamlineUrlId}/${fileMetadata.urlId}`
+    : beamlineUrlId;
+
+  executeAction(
+    {
+      type: "OPEN_PAGE",
+      dynamicInfo: {
+        name: newScreen,
+        location: "main",
+        description: undefined,
+        file: {
+          path: newScreen,
+          macros: macros,
+          defaultProtocol: "ca"
+        }
+      }
+    },
+    fileContext,
+    undefined,
+    {},
+    urlPath
+  );
+};


### PR DESCRIPTION
This PR inserts the macros from the JsonMap file into the call to execute action.
I've also wrapped the call to executeAction in a utility function, so that we can standardise the data mapping to form the arguments for executeAction.