### PR TITLE
Use display names in tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Daedalus</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/routes/DataBrowserPage.tsx
+++ b/src/routes/DataBrowserPage.tsx
@@ -3,7 +3,7 @@ import ArchiverMenuBar from "../components/ArchiverMenuBar";
 import TracesPanel from "../components/TracesPanel";
 import DataBrowserPlot from "../components/DataBrowserPlot";
 import DLSAppBar from "../components/AppBar";
-import { createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 
 export const MenuContext = createContext<{
   menusOpen: {
@@ -20,6 +20,11 @@ export const MenuContext = createContext<{
  */
 export function DataBrowserPage() {
   const [menusOpen, setMenusOpen] = useState({ trace: false, archiver: false });
+
+  useEffect(() => {
+    document.title = "Data Browser | Daedalus";
+  }, []);
+
   return (
     <MenuContext.Provider value={{ menusOpen, setMenusOpen }}>
       <Box sx={{ display: "flex", width: "100%" }}>

--- a/src/routes/DemoPage.tsx
+++ b/src/routes/DemoPage.tsx
@@ -4,7 +4,7 @@ import { demoReducer, demoInitialState, FileState } from "../store";
 import { useWindowWidth, useWindowHeight } from "../utils/helper";
 import FileDisplay from "../components/FileDisplay";
 import FileNavigationBar from "../components/FileNavigationBar";
-import { createContext } from "react";
+import { createContext, useEffect } from "react";
 import DLSAppBar from "../components/AppBar";
 
 const FileStateContext = createContext<{
@@ -16,6 +16,10 @@ export function DemoPage() {
   const [state, dispatch] = React.useReducer(demoReducer, demoInitialState);
   const width = useWindowWidth();
   const height = useWindowHeight();
+
+  useEffect(() => {
+    document.title = "Demo | Daedalus";
+  }, []);
 
   return (
     <>

--- a/src/routes/EditorPage.tsx
+++ b/src/routes/EditorPage.tsx
@@ -41,6 +41,7 @@ export function EditorPage() {
 
   // Only run once on mount
   useEffect(() => {
+    document.title = "Editor | Daedalus";
     loadScreens();
   }, []);
 

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -3,8 +3,13 @@ import DLSAppBar from "../components/AppBar";
 import { useWindowHeight, APP_BAR_HEIGHT } from "../utils/helper";
 import LinkCard from "../components/LinkCard";
 import { PageRouteInfo } from "./PageRouteInfo";
+import { useEffect } from "react";
 
 export function LandingPage() {
+  useEffect(() => {
+    document.title = "Home | Daedalus";
+  }, []);
+
   // get width
   return (
     <>

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -50,6 +50,7 @@ export function SynopticPage() {
 
   useEffect(() => {
     // Only trigger once
+    document.title = `${params.beamline} Synoptic | Daedalus`;
     if (state.filesLoaded) {
       if (params.beamline && params.beamline !== state.currentBeamline)
         dispatch({
@@ -66,6 +67,7 @@ export function SynopticPage() {
 
   // Only run once on mount
   useEffect(() => {
+    document.title = "Synoptic | Daedalus";
     loadScreens();
   }, []);
 

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -17,7 +17,11 @@ export async function parseScreenTree(
     const response = await httpRequest(filepath);
     const json = await response.json();
 
-    const { urlId, fileLabel: topLevelScreen } = buildUrlId(json.file, "");
+    const { urlId, fileLabel: topLevelScreen } = buildUrlId(
+      json.file,
+      json.displayName,
+      ""
+    );
 
     // Process the child items
     const { fileMap, treeViewItems } = RecursiveTreeViewBuilder(
@@ -76,7 +80,11 @@ export const RecursiveTreeViewBuilder = (
   }
 
   for (const sibling of jsonSiblings) {
-    const { urlId, fileLabel } = buildUrlId(sibling.file, idPrefix);
+    const { urlId, fileLabel } = buildUrlId(
+      sibling.file,
+      sibling.displayName,
+      idPrefix
+    );
     const guid = crypto.randomUUID();
 
     const treeViewItem: TreeViewBaseItem = {
@@ -88,9 +96,9 @@ export const RecursiveTreeViewBuilder = (
     if (!sibling.duplicate) {
       fileMap[guid] = {
         file: sibling.file,
-        urlId,
-        macros: sibling.macros ? [sibling.macros] : [],
-        exists: sibling?.exists
+        exists: sibling?.exists,
+        urlId: urlId,
+        macros: sibling.macros ? [sibling.macros] : []
       };
 
       // If not a duplicate, check for children
@@ -139,9 +147,13 @@ export const RecursiveAppendDuplicateFileMacros = (
   }
 };
 
-const buildUrlId = (filepath: string, idPrefix: string) => {
+const buildUrlId = (
+  filepath: string,
+  displayName: string,
+  idPrefix: string
+) => {
   const splitFilePath = filepath.split(".bob")[0].split("/");
-  let fileLabel: string = splitFilePath.pop()!;
+  let fileLabel: string = displayName || splitFilePath.pop()!;
   if (fileLabel === "index") {
     const parentDir = splitFilePath.pop();
     if (parentDir) {

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -19,8 +19,8 @@ export async function parseScreenTree(
 
     const { urlId, fileLabel: topLevelScreen } = buildUrlId(
       json.file,
-      json.displayName,
-      ""
+      "",
+      json.displayName
     );
 
     // Process the child items
@@ -82,8 +82,8 @@ export const RecursiveTreeViewBuilder = (
   for (const sibling of jsonSiblings) {
     const { urlId, fileLabel } = buildUrlId(
       sibling.file,
-      sibling.displayName,
-      idPrefix
+      idPrefix,
+      sibling.displayName
     );
     const guid = crypto.randomUUID();
 
@@ -147,10 +147,17 @@ export const RecursiveAppendDuplicateFileMacros = (
   }
 };
 
-const buildUrlId = (
+/**
+ *
+ * @param filepath string path of bob file
+ * @param idPrefix string prefix of all parent file IDs
+ * @param displayName string alternate name of file to display
+ * @returns string ID of url, label to display for current file
+ */
+export const buildUrlId = (
   filepath: string,
-  displayName: string,
-  idPrefix: string
+  idPrefix: string,
+  displayName?: string
 ) => {
   const splitFilePath = filepath.split(".bob")[0].split("/");
   let fileLabel: string = displayName || splitFilePath.pop()!;

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -148,7 +148,8 @@ export const RecursiveAppendDuplicateFileMacros = (
 };
 
 /**
- *
+ * Builds the ID to display in the URL, based on the file name
+ * and/or a given display name
  * @param filepath string path of bob file
  * @param idPrefix string prefix of all parent file IDs
  * @param displayName string alternate name of file to display


### PR DESCRIPTION
This PR:

- Adds capability to use a display name (passed in via JSON map) instead of the .bob file name in the tree and the breadcrumbs
- Adds titles to the browser tab depending on the page currently viewed. For a selected beamline in the Synoptic page, this title includes the beamline name