### PR TITLE
Match JsonMap record by both file path and macros

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daedalus",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus",
-      "version": "0.0.11",
+      "version": "0.0.13",
       "dependencies": {
         "@diamondlightsource/cs-web-lib": "^0.9.10",
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ScreenDisplay.tsx
+++ b/src/components/ScreenDisplay.tsx
@@ -19,6 +19,7 @@ import {
 import { BeamlineTreeStateContext } from "../App";
 import { MenuContext } from "../routes/SynopticPage";
 import { useLocation, useNavigate } from "react-router-dom";
+import { selectFileMetadataByFilePathAndMacros } from "../utils/parser";
 
 interface PaperProps extends MuiPaperProps {
   open?: boolean;
@@ -66,9 +67,10 @@ export default function ScreenDisplay() {
         ""
       );
 
-      const allFiles = state.beamlines[state.currentBeamline].filePathIds;
-      const currentFile = Object.values(allFiles).find(
-        values => values.file === displayedPath
+      const currentFile = selectFileMetadataByFilePathAndMacros(
+        state.beamlines[state.currentBeamline].filePathIds,
+        displayedPath,
+        fileContext.pageState.main?.macros
       );
 
       if (currentFile?.urlId && currentFile.urlId !== pathname) {

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -12,11 +12,14 @@ import {
   BeamlineState,
   CHANGE_BEAMLINE,
   CHANGE_SCREEN,
-  LOAD_SCREENS
+  LOAD_SCREENS,
 } from "../store";
 import DLSAppBar from "../components/AppBar";
 import ScreenDisplay from "../components/ScreenDisplay";
-import { parseScreenTree } from "../utils/parser";
+import {
+  parseScreenTree,
+  selectFileMetadataByFilePathAndMacros
+} from "../utils/parser";
 import {
   buildUrl,
   FileContext,
@@ -121,6 +124,7 @@ export function SynopticPage() {
         const macrosMap = macrosParameter
           ? JSON.parse(macrosParameter)
           : undefined;
+
         executeOpenPageActionWithUrlId(
           newBeamlineState,
           params.screenUrlId,
@@ -194,21 +198,23 @@ export const addTabCallbackAction =
       ""
     );
 
-    const allFiles = beamlines[currentBeamline].filePathIds;
-    const currentFile = Object.values(allFiles).find(
-      values => values.file === displayedPath
+    const matchingFileMetadata = selectFileMetadataByFilePathAndMacros(
+      beamlines[currentBeamline].filePathIds,
+      displayedPath,
+      fileDesc?.macros
     );
 
     // Build the URL for the new tab
     let newURL = new URL(windowLocation.origin);
-    if (currentFile?.urlId) {
+    if (matchingFileMetadata?.urlId) {
       // we have a file mapping
       newURL.pathname = buildUrl(
         "",
         "synoptic",
         currentBeamline,
-        currentFile?.urlId
+        matchingFileMetadata?.urlId
       );
+
       if (fileDesc?.macros) {
         newURL.searchParams.append(
           MACROS_SEARCH_PARAMETER_NAME,

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -12,7 +12,7 @@ import {
   BeamlineState,
   CHANGE_BEAMLINE,
   CHANGE_SCREEN,
-  LOAD_SCREENS,
+  LOAD_SCREENS
 } from "../store";
 import DLSAppBar from "../components/AppBar";
 import ScreenDisplay from "../components/ScreenDisplay";

--- a/src/tests/routes/SynopticPage.test.tsx
+++ b/src/tests/routes/SynopticPage.test.tsx
@@ -141,15 +141,23 @@ describe("addTabCallbackAction", () => {
     bl01: {
       host: "http://daedalus.ac.uk",
       filePathIds: {
-        file1: { urlId: "screen1", file: "/path/to/file1" },
-        file2: { urlId: "screen2", file: "/path/to/file2" }
+        file1: {
+          urlId: "screen1",
+          file: "/path/to/file1",
+          macros: [{ key: "value" }]
+        },
+        file2: {
+          urlId: "screen2",
+          file: "/path/to/file2",
+          macros: [{ key: "value2" }]
+        }
       }
     } as Partial<BeamlineStateProperties> as BeamlineStateProperties
   } as Partial<BeamlineState> as BeamlineState;
 
   const mockLocation = {
-    origin: "http://localhost:3000",
-    href: "http://localhost:3000/synoptic/bl01/screen1",
+    origin: "http://daedalus.ac.uk",
+    href: "http://daedalus.ac.uk/synoptic/bl01/screen1",
     pathname: "/synoptic/bl01/screen1"
   } as Location;
 
@@ -165,7 +173,7 @@ describe("addTabCallbackAction", () => {
     const addTab = addTabCallbackAction(mockBeamlines, "bl01", mockLocation);
 
     const fileDesc = {
-      path: "http://daedalus.ac.uk/path/to/file1",
+      path: "/path/to/file1",
       macros: { key: "value" }
     } as Partial<FileDescription> as FileDescription;
 

--- a/src/tests/utils/csWebLibActions.test.ts
+++ b/src/tests/utils/csWebLibActions.test.ts
@@ -67,7 +67,7 @@ describe("executeAction: OPEN_PAGE", () => {
           type: "OPEN_PAGE",
           dynamicInfo: expect.objectContaining({
             file: expect.objectContaining({
-              macros: { key1: "value1", key2: "value2" }
+              macros: { key1: "value1" }
             })
           })
         }),
@@ -203,7 +203,7 @@ describe("executeAction: OPEN_PAGE", () => {
             description: undefined,
             file: {
               path: expectedUrl,
-              macros: { param1: "value1", param2: "value2", param3: "value3" },
+              macros: { param1: "value1" },
               defaultProtocol: "ca"
             }
           }

--- a/src/utils/csWebLibActions.ts
+++ b/src/utils/csWebLibActions.ts
@@ -41,18 +41,23 @@ export const executeOpenPageActionWithFileMetadata = (
   fileMetadata: FileMetadata | undefined,
   selectedBeamlineId: string,
   fileContext: any,
-  extraMacros?: MacroMap
+  overrideMacros?: MacroMap
 ) => {
   const newScreen = buildUrl(
     beamlineState.host,
     fileMetadata?.file ?? beamlineState.topLevelScreen
   );
 
-  const macros: MacroMap =
-    fileMetadata?.macros?.reduce((acc, obj) => Object.assign(acc, obj), {}) ??
-    {};
+  const fileMetadataMacros: MacroMap =
+    fileMetadata?.macros && fileMetadata?.macros.length > 0
+      ? fileMetadata?.macros[0]
+      : {};
 
-  const allMacros = extraMacros ? { ...extraMacros, ...macros } : macros;
+  const selectedMacros =
+    overrideMacros && Object.entries(overrideMacros).length > 0
+      ? overrideMacros
+      : fileMetadataMacros;
+
   const beamlineUrlId = `/synoptic/${selectedBeamlineId}`;
 
   const urlPath = fileMetadata?.urlId
@@ -61,7 +66,13 @@ export const executeOpenPageActionWithFileMetadata = (
 
   const protocol = "ca";
 
-  executeOpenPageAction(newScreen, allMacros, protocol, fileContext, urlPath);
+  executeOpenPageAction(
+    newScreen,
+    selectedMacros,
+    protocol,
+    fileContext,
+    urlPath
+  );
 };
 
 export const executeOpenPageAction = (


### PR DESCRIPTION
This adds the capability to match the JSON map screen record by both the file path and macros.

- There must be an exact match with the macros and filename.
- The method `selectFileMetadataByFilePathAndMacros`  does the searching.

Note that CS-WEB-LIB injects the macros LCID and DID, these should be ignored.