### PR TITLE
Upgrade to router 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "react-dom": "^18.3.1",
         "react-loader-spinner": "^6.1.6",
         "react-redux": "^7.2.9",
-        "react-router-dom": "^6.30.2",
+        "react-router": "^7.13.0",
         "xml-js": "^1.6.11"
       },
       "devDependencies": {
@@ -48,7 +48,7 @@
     },
     "../cs-web-lib": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "extraneous": true,
       "license": "ISC",
       "dependencies": {
@@ -94,6 +94,7 @@
         "prettier": "^3.3.3",
         "react-gauge-component": "^1.2.64",
         "react-id-generator": "^3.0.2",
+        "react-router": "^7.13.0",
         "react-test-renderer": "^18.3.1",
         "react-tiny-popover": "^8.1.2",
         "rollup": "^4",
@@ -115,7 +116,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^7.2.9",
-        "react-router-dom": "^6.30.2"
+        "react-router": "^7.13.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2180,6 +2181,7 @@
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
       "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2654,13 +2656,13 @@
       }
     },
     "node_modules/@turf/area": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.2.tgz",
-      "integrity": "sha512-d7IuEjAO3TSX5aVeL5WXrtCZCwxUAUOD4+LZ+VjoEe2THmYKdUknCPbH6rdhMBzLyZNuSVRmpRD/QfpCnLqoZg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.3.tgz",
+      "integrity": "sha512-FT66TCxUec+3RsCCyO1kWP57/tiEWEqYfpIs5n44dup401Cne/E+xunahEWxMfP/HSUxfcRQqrjH5vEulLrNoA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.2",
-        "@turf/meta": "7.3.2",
+        "@turf/helpers": "7.3.3",
+        "@turf/meta": "7.3.3",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -2669,13 +2671,13 @@
       }
     },
     "node_modules/@turf/bbox": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.2.tgz",
-      "integrity": "sha512-iohGIDVqi8Ck7VQY2Emp490BShWKixG8wkVPQ7qO4fXRqJwrWO7ntU9XPB+r0qs6Y8kaSd+nDnvG3VFfKDb+Vg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.3.tgz",
+      "integrity": "sha512-1zNO/JUgDp0N+3EG5fG7+8EolE95OW1LD8ur0hRP0JK+lRyN0gAvJT7n1I9pu/NIqTa8x/zXxGRc1dcOdohYkg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.2",
-        "@turf/meta": "7.3.2",
+        "@turf/helpers": "7.3.3",
+        "@turf/meta": "7.3.3",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -2684,13 +2686,13 @@
       }
     },
     "node_modules/@turf/centroid": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.2.tgz",
-      "integrity": "sha512-zWlX/t7goUx+FqCYzyscO7muXPSADb5nTGXWAbRR51P3Zsdx24P5tJshJhrHwIb3OR9a+YE4ig568Clex6tc2g==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.3.tgz",
+      "integrity": "sha512-3vWLnF1CksLk7xTUH11IzOQJ6fOoj7zhuL8M3GTxcKruVkGat/vIm3Ye5b68sDVcE5nFDA2pYjjbL7Rfmn3/GQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.2",
-        "@turf/meta": "7.3.2",
+        "@turf/helpers": "7.3.3",
+        "@turf/meta": "7.3.3",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -2699,9 +2701,9 @@
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.2.tgz",
-      "integrity": "sha512-5HFN42rgWjSobdTMxbuq+ZdXPcqp1IbMgFYULTLCplEQM3dXhsyRFe7DCss4Eiw12iW3q6Z5UeTNVfITsE5lgA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.3.tgz",
+      "integrity": "sha512-9Ias0L1GuZPIzO6sk8jraTEuLJye6n9LYNEdw69ZGOQ6C1IigjxkPW49zmn21aTv1z27vxdVLSS3r+78DB2QnQ==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
@@ -2712,12 +2714,12 @@
       }
     },
     "node_modules/@turf/meta": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.2.tgz",
-      "integrity": "sha512-FIcIY+ZsAe9QV4fHciTXeuRz2TKIVaEjivkl4vMFCibdj7FUkWDofqOncbIre1xPrgktQeh20ZrmD+p0kf3n4Q==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.3.tgz",
+      "integrity": "sha512-Tz1j4h70iFB5SebWWoVv/uL59x4aOngXU+d1xQDXzOCn/O6txnreGVGMcYU362c5F06yqZx38H9UFTQ553lK0w==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.2",
+        "@turf/helpers": "7.3.3",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -4608,6 +4610,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.46.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
@@ -4810,19 +4825,19 @@
       "license": "MIT"
     },
     "node_modules/css-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.3.tgz",
+      "integrity": "sha512-frbERmjT0UC5lMheWpJmMilnt9GEhbZJN/heUb7/zaJYeIzj5St9HvDcfshzzOqbsS+rYpMk++2SD3vGETDSyA==",
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.40",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
+        "semver": "^7.6.3"
       },
       "engines": {
         "node": ">= 18.12.0"
@@ -9783,18 +9798,25 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
@@ -9802,6 +9824,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "react-router": "6.30.3"
@@ -9812,6 +9835,22 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {
@@ -10489,9 +10528,10 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10508,6 +10548,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "daedalus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
-        "@diamondlightsource/cs-web-lib": "^0.9.13",
+        "@diamondlightsource/cs-web-lib": "^0.10.0",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.17",
@@ -48,7 +48,7 @@
     },
     "../cs-web-lib": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.9.13",
+      "version": "0.10.0",
       "extraneous": true,
       "license": "ISC",
       "dependencies": {
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@diamondlightsource/cs-web-lib": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@diamondlightsource/cs-web-lib/-/cs-web-lib-0.9.13.tgz",
-      "integrity": "sha512-L+rKA0B5mypvDw4W+vI6nD07ZtkubGpLHdPMbD+HAWJVJTAsIa8VaKoZSlT1zHGDMKBVRFI7IRKdXYWZ6WgsTQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@diamondlightsource/cs-web-lib/-/cs-web-lib-0.10.0.tgz",
+      "integrity": "sha512-WO5BMNd1p8NXSRu9yV/RvObDmfPL/2YBT1oMkIqZWrFHIdLkaCbNZ72LnUhaGx9j6j0MhaF/kaFlmllFH3gG3Q==",
       "license": "ISC",
       "dependencies": {
         "apollo-link-retry": "^2.2.16",
@@ -663,7 +663,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^7.2.9",
-        "react-router-dom": "^6.30.2"
+        "react-router": "^7.13.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2174,16 +2174,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -9817,40 +9807,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.23.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -15,7 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@diamondlightsource/cs-web-lib": "^0.9.13",
+    "@diamondlightsource/cs-web-lib": "^0.10.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.17",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.3.1",
     "react-loader-spinner": "^6.1.6",
     "react-redux": "^7.2.9",
-    "react-router-dom": "^6.30.2",
+    "react-router": "^7.13.0",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,7 @@ export const appRouter = createBrowserRouter([
         children: [
           { index: true, element: <SynopticPage /> },
           { path: ":beamline", element: <SynopticPage /> },
-          { path: ":beamline/:screenUrlId", element: <SynopticPage /> }
+          { path: ":beamline/*", element: <SynopticPage /> }
         ]
       },
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { FileProvider, store } from "@diamondlightsource/cs-web-lib";
-import { BrowserRouter, Route, Routes } from "react-router";
+import { createBrowserRouter, Outlet } from "react-router";
 import "./App.css";
 import { Provider } from "react-redux";
 import { ThemeProvider } from "@mui/material/styles";
@@ -32,7 +32,7 @@ export const BeamlineTreeStateContext = createContext<{
   dispatch: React.Dispatch<any>;
 }>({ state: initialState, dispatch: () => null });
 
-function App({}) {
+const App = ({}) => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const [config, setConfig] = useState<DaedalusConfig | null>(null);
 
@@ -66,27 +66,35 @@ function App({}) {
   return (
     <Provider store={store(config)}>
       <ThemeProvider theme={diamondTheme}>
-        <BrowserRouter>
-          <BeamlineTreeStateContext.Provider value={{ state, dispatch }}>
-            <FileProvider initialPageState={INITIAL_SCREEN_STATE}>
-              <Routes>
-                <Route path="/demo" element={<DemoPage />} />
-                <Route path="/data-browser" element={<DataBrowserPage />} />
-                <Route path="/editor" element={<EditorPage />} />
-                <Route path="/synoptic" element={<SynopticPage />} />
-                <Route path="/synoptic/:beamline" element={<SynopticPage />} />
-                <Route
-                  path="/synoptic/:beamline/:screenUrlId"
-                  element={<SynopticPage />}
-                />
-                <Route path="/" element={<LandingPage />} />
-              </Routes>
-            </FileProvider>
-          </BeamlineTreeStateContext.Provider>
-        </BrowserRouter>
+        <BeamlineTreeStateContext.Provider value={{ state, dispatch }}>
+          <FileProvider initialPageState={INITIAL_SCREEN_STATE}>
+            <Outlet />
+          </FileProvider>
+        </BeamlineTreeStateContext.Provider>
       </ThemeProvider>
     </Provider>
   );
-}
+};
 
-export default App;
+export const appRouter = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      { path: "/demo", element: <DemoPage /> },
+      { path: "/data-browser", element: <DataBrowserPage /> },
+      { path: "/editor", element: <EditorPage /> },
+
+      {
+        path: "/synoptic",
+        children: [
+          { index: true, element: <SynopticPage /> },
+          { path: ":beamline", element: <SynopticPage /> },
+          { path: ":beamline/:screenUrlId", element: <SynopticPage /> }
+        ]
+      },
+
+      { index: true, element: <LandingPage /> }
+    ]
+  }
+]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { FileProvider, store } from "@diamondlightsource/cs-web-lib";
-import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router";
 import "./App.css";
 import { Provider } from "react-redux";
 import { ThemeProvider } from "@mui/material/styles";
@@ -66,7 +66,7 @@ function App({}) {
   return (
     <Provider store={store(config)}>
       <ThemeProvider theme={diamondTheme}>
-        <Router>
+        <BrowserRouter>
           <BeamlineTreeStateContext.Provider value={{ state, dispatch }}>
             <FileProvider initialPageState={INITIAL_SCREEN_STATE}>
               <Routes>
@@ -83,7 +83,7 @@ function App({}) {
               </Routes>
             </FileProvider>
           </BeamlineTreeStateContext.Provider>
-        </Router>
+        </BrowserRouter>
       </ThemeProvider>
     </Provider>
   );

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -9,7 +9,7 @@ import { APP_BAR_HEIGHT, DRAWER_WIDTH } from "../utils/helper";
 import { Box, Tooltip } from "@mui/material";
 import DiamondLogo from "../assets/DiamondLogoWhite.svg";
 import { PageRouteInfo } from "../routes/PageRouteInfo";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 interface AppBarProps extends MuiAppBarProps {
   fullscreen: number;

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -6,7 +6,7 @@ import {
   CardActionArea,
   useTheme
 } from "@mui/material";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 interface LinkCardProps extends CardProps {
   info: {
     name: string;

--- a/src/components/ScreenDisplay.tsx
+++ b/src/components/ScreenDisplay.tsx
@@ -18,7 +18,7 @@ import {
 } from "../utils/helper";
 import { BeamlineTreeStateContext } from "../App";
 import { MenuContext } from "../routes/SynopticPage";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { selectFileMetadataByFilePathAndMacros } from "../utils/parser";
 
 interface PaperProps extends MuiPaperProps {

--- a/src/components/SynopticBreadcrumbs.tsx
+++ b/src/components/SynopticBreadcrumbs.tsx
@@ -8,7 +8,8 @@ import { BeamlineTreeStateContext } from "../App";
 import { executeOpenPageActionWithUrlId } from "../utils/csWebLibActions";
 import {
   buildSynopticScreenPath,
-  extractAncestorScreens
+  extractAncestorScreens,
+  parseFullSynopticPath
 } from "../utils/screenUrlIdUtils";
 
 export const SynopticBreadcrumbs = () => {
@@ -53,13 +54,12 @@ const handleClick =
   (event: any) => {
     if (event.target.pathname) {
       event.preventDefault();
-      const urlId = decodeURI(event.target.pathname)
-        .split("/")
-        .at(-1) as string;
+
+      const params = parseFullSynopticPath(decodeURI(event.target.pathname));
 
       executeOpenPageActionWithUrlId(
         beamlineState,
-        urlId,
+        params?.screenUrlId,
         selectedBeamlineId,
         fileContext
       );

--- a/src/components/SynopticBreadcrumbs.tsx
+++ b/src/components/SynopticBreadcrumbs.tsx
@@ -6,6 +6,10 @@ import { FileContext } from "@diamondlightsource/cs-web-lib";
 import { BeamlineStateProperties } from "../store";
 import { BeamlineTreeStateContext } from "../App";
 import { executeOpenPageActionWithUrlId } from "../utils/csWebLibActions";
+import {
+  buildSynopticScreenPath,
+  extractAncestorScreens
+} from "../utils/screenUrlIdUtils";
 
 export const SynopticBreadcrumbs = () => {
   const { state } = useContext(BeamlineTreeStateContext);
@@ -71,21 +75,24 @@ const createBreadcrumbs = (
   beamline: string
 ): ReactNode => {
   const breadcrumbs: ReactNode[] = [];
-  if (beamline === "") return null;
-  const breadcrumbLabels = screenUrlId.split("+");
-  let linkUrl = `/synoptic/${beamline}/`;
+  if (!beamline || beamline === "") return null;
 
-  breadcrumbLabels.forEach((label, idx) => {
-    if (idx !== 0) linkUrl += "+";
-    linkUrl += label;
+  const screenAncestry = extractAncestorScreens(screenUrlId);
+
+  screenAncestry.forEach((item, idx) => {
     breadcrumbs.push(
-      idx === breadcrumbLabels.length - 1 ? (
+      idx === screenAncestry.length - 1 ? (
         <Typography key="3" sx={{ color: "white" }}>
-          {label}
+          {item.displayName}
         </Typography>
       ) : (
-        <Link underline="hover" key={idx} color="white" href={linkUrl}>
-          {label}
+        <Link
+          underline="hover"
+          key={idx}
+          color="white"
+          href={buildSynopticScreenPath(beamline, item.path)}
+        >
+          {item.displayName}
         </Link>
       )
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,14 @@
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
+import { appRouter } from "./App.tsx";
 import "./index.css";
 import { OutlineProvider } from "@diamondlightsource/cs-web-lib";
+import { RouterProvider } from "react-router";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);
 
 root.render(
   <OutlineProvider>
-    <App />
+    <RouterProvider router={appRouter} />
   </OutlineProvider>
 );

--- a/src/routes/EditorPage.tsx
+++ b/src/routes/EditorPage.tsx
@@ -10,7 +10,7 @@ import {
 import { parseScreenTree } from "../utils/parser";
 import { FileContext } from "@diamondlightsource/cs-web-lib";
 import Editor from "../components/Editor";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { executeOpenPageActionWithUrlId } from "../utils/csWebLibActions";
 
 /**

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -45,28 +45,31 @@ export const MenuContext = createContext<{
 
 export function SynopticPage() {
   const { state, dispatch } = useContext(BeamlineTreeStateContext);
-  const params: { beamline?: string; screenUrlId?: string } = useParams();
   const fileContext = useContext(FileContext);
   const [searchParams] = useSearchParams();
   const [menuOpen, setMenuOpen] = useState(true);
   const location = useLocation();
 
+  const params = useParams();
+  const paramsBeamline: string | undefined = params.beamline;
+  const paramsScreenUrlId: string | undefined = params["*"];
+
   useEffect(() => {
     // Only trigger once
-    document.title = `${params.beamline} Synoptic | Daedalus`;
+    document.title = `${paramsBeamline ?? ""} Synoptic | Daedalus`;
     if (state.filesLoaded) {
-      if (params.beamline && params.beamline !== state.currentBeamline)
+      if (paramsBeamline && paramsBeamline !== state.currentBeamline)
         dispatch({
           type: CHANGE_BEAMLINE,
-          payload: { beamline: params.beamline }
+          payload: { beamline: paramsBeamline }
         });
-      if (params.screenUrlId && params.screenUrlId !== state.currentScreenUrlId)
+      if (paramsScreenUrlId && paramsScreenUrlId !== state.currentScreenUrlId)
         dispatch({
           type: CHANGE_SCREEN,
-          payload: { screenUrlId: params.screenUrlId }
+          payload: { screenUrlId: paramsScreenUrlId }
         });
     }
-  }, [params.beamline, params.screenUrlId]);
+  }, [paramsBeamline, paramsScreenUrlId]);
 
   // Only run once on mount
   useEffect(() => {
@@ -76,7 +79,7 @@ export function SynopticPage() {
 
   const loadScreens = useCallback(async () => {
     const newBeamlines = { ...state.beamlines };
-    for (const [beamline, item] of Object.entries(newBeamlines)) {
+    for (const [newBeamline, item] of Object.entries(newBeamlines)) {
       try {
         const [tree, fileIDs, firstFile] = await parseScreenTree(
           buildUrl(item.host, item.entryPoint)
@@ -87,7 +90,7 @@ export function SynopticPage() {
         item.loaded = true;
       } catch (e) {
         console.error(
-          `Unable to process JSON map for ${beamline}. Check file is available at ${item.host + item.entryPoint} and reload.`
+          `Unable to process JSON map for ${newBeamline}. Check file is available at ${item.host + item.entryPoint} and reload.`
         );
         console.error(e);
       }
@@ -96,13 +99,13 @@ export function SynopticPage() {
       type: LOAD_SCREENS,
       payload: {
         beamlines: newBeamlines,
-        loadBeamline: params.beamline,
-        loadScreen: params.screenUrlId
+        loadBeamline: paramsBeamline,
+        loadScreen: paramsScreenUrlId
       }
     });
-    if (params.beamline) {
+    if (paramsBeamline) {
       // If we navigated directly to a beamline and/or screen, load in display
-      const newBeamlineState = newBeamlines[params.beamline];
+      const newBeamlineState = newBeamlines[paramsBeamline];
 
       const fileDescriptionParam = searchParams.get(
         FILE_DESCRIPTION_SEARCH_PARAMETER_NAME
@@ -127,8 +130,8 @@ export function SynopticPage() {
 
         executeOpenPageActionWithUrlId(
           newBeamlineState,
-          params.screenUrlId,
-          params.beamline,
+          paramsScreenUrlId,
+          paramsBeamline,
           fileContext,
           macrosMap
         );

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -45,14 +45,11 @@ export const MenuContext = createContext<{
 
 export function SynopticPage() {
   const { state, dispatch } = useContext(BeamlineTreeStateContext);
+  const { beamline: paramsBeamline, "*": paramsScreenUrlId } = useParams();
   const fileContext = useContext(FileContext);
   const [searchParams] = useSearchParams();
   const [menuOpen, setMenuOpen] = useState(true);
   const location = useLocation();
-
-  const params = useParams();
-  const paramsBeamline: string | undefined = params.beamline;
-  const paramsScreenUrlId: string | undefined = params["*"];
 
   useEffect(() => {
     // Only trigger once

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -29,7 +29,7 @@ import {
 import { RotatingLines } from "react-loader-spinner";
 import { SynopticBreadcrumbs } from "../components/SynopticBreadcrumbs";
 import { BeamlineTreeStateContext } from "../App";
-import { useParams, useSearchParams, useLocation } from "react-router-dom";
+import { useParams, useSearchParams, useLocation } from "react-router";
 import {
   executeOpenPageActionWithUrlId,
   executeOpenPageAction

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { TreeViewBaseItem } from "@mui/x-tree-view";
 import { BeamlinesConfig } from "./config";
+import { extractDisplayNameFromScreenUrlId } from "./utils/screenUrlIdUtils";
 export const LOAD_NEXT_FILE = "loadNextFile";
 export const ADD_FILE = "addFile";
 export const REMOVE_FILE = "removeFile";
@@ -297,8 +298,9 @@ export function reducer(
       };
     }
     case CHANGE_SCREEN: {
-      // Parse the label from the end of the ID. This is the specific screen name
-      const newLabel = action.payload.screenUrlId.split("+").pop() || "";
+      const newLabel = extractDisplayNameFromScreenUrlId(
+        action.payload.screenUrlId
+      );
       const beamlineFilePaths =
         state.beamlines[state.currentBeamline].filePathIds;
       const screenId = Object.keys(beamlineFilePaths).find(

--- a/src/tests/components/AppBar.test.tsx
+++ b/src/tests/components/AppBar.test.tsx
@@ -5,13 +5,13 @@ import DLSAppBar, { StyledAppBar } from "../../components/AppBar";
 import { PageRouteInfo } from "../../routes/PageRouteInfo";
 import { createTheme, ThemeProvider } from "@mui/material";
 import { DRAWER_WIDTH } from "../../utils/helper";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 console.log = vi.fn();
 
 const mockHistoryPush = vi.fn();
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual("react-router-dom");
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
   return {
     ...actual,
     useNavigate: () => mockHistoryPush

--- a/src/tests/components/LinkCard.test.tsx
+++ b/src/tests/components/LinkCard.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import LinkCard from "../../components/LinkCard";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 
 const mockHistoryPush = vi.fn();
 
-vi.mock("react-router-dom", async importOriginal => {
-  const actual = await importOriginal<typeof import("react-router-dom")>();
+vi.mock("react-router", async importOriginal => {
+  const actual = await importOriginal<typeof import("react-router")>();
   return {
     ...actual,
     useNavigate: () => mockHistoryPush

--- a/src/tests/components/LinkCard.test.tsx
+++ b/src/tests/components/LinkCard.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import LinkCard from "../../components/LinkCard";
-import { BrowserRouter } from "react-router";
+import { MemoryRouter } from "react-router";
 
 const mockHistoryPush = vi.fn();
 
@@ -21,9 +21,9 @@ describe("LinkCard", (): void => {
       text: "A test."
     };
     const { getByText } = render(
-      <BrowserRouter>
+      <MemoryRouter>
         <LinkCard info={info} />
-      </BrowserRouter>
+      </MemoryRouter>
     );
     const card = getByText("Testing");
     expect(card).toBeInTheDocument();

--- a/src/tests/components/SynopticBreadcrumbs.test.tsx
+++ b/src/tests/components/SynopticBreadcrumbs.test.tsx
@@ -9,6 +9,8 @@ import {
 } from "../../store";
 import { BeamlineTreeStateContext } from "../../App";
 
+const EXPECTED_SEPARATOR = "/";
+
 vi.mock("@diamondlightsource/cs-web-lib", async () => {
   const actual = await vi.importActual("@diamondlightsource/cs-web-lib");
   return {
@@ -23,7 +25,7 @@ describe("SynopticBreadcrumbs Component", () => {
   });
 
   const createMockState = (
-    screenUrlId = "Area1+Area2",
+    screenUrlId = `Area1${EXPECTED_SEPARATOR}Area2`,
     beamline?: string,
     screenGuid: string = crypto.randomUUID()
   ): BeamlineTreeState =>
@@ -38,7 +40,10 @@ describe("SynopticBreadcrumbs Component", () => {
               host: "http://example.com/",
               filePathIds: {
                 Area1: { urlId: "Area1", file: "area1.opi" },
-                [screenGuid]: { urlId: "Area1+Area2", file: "area2.opi" }
+                [screenGuid]: {
+                  urlId: `Area1${EXPECTED_SEPARATOR}Area2`,
+                  file: "area2.opi"
+                }
               }
             } as unknown as BeamlineStateProperties
           } as unknown as BeamlineState),
@@ -94,11 +99,19 @@ describe("SynopticBreadcrumbs Component", () => {
   });
 
   it("renders breadcrumbs with correct URLs", () => {
-    renderComponent(createMockState("Area1+Area2+Area3", "BL01"));
+    renderComponent(
+      createMockState(
+        `Area1${EXPECTED_SEPARATOR}Area2${EXPECTED_SEPARATOR}Area3`,
+        "BL01"
+      )
+    );
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute("href", "/synoptic/BL01/Area1");
-    expect(links[1]).toHaveAttribute("href", "/synoptic/BL01/Area1+Area2");
+    expect(links[1]).toHaveAttribute(
+      "href",
+      `/synoptic/BL01/Area1${EXPECTED_SEPARATOR}Area2`
+    );
 
     expect(screen.getByText("Area3").tagName).not.toBe("A");
   });
@@ -141,7 +154,12 @@ describe("SynopticBreadcrumbs Component", () => {
   });
 
   it("handles multi-level breadcrumb paths correctly", () => {
-    renderComponent(createMockState("Level1+Level2+Level3+Level4", "BL02"));
+    renderComponent(
+      createMockState(
+        `Level1${EXPECTED_SEPARATOR}Level2${EXPECTED_SEPARATOR}Level3${EXPECTED_SEPARATOR}Level4`,
+        "BL02"
+      )
+    );
 
     expect(screen.getByText("Level1")).toBeInTheDocument();
     expect(screen.getByText("Level2")).toBeInTheDocument();
@@ -151,10 +169,13 @@ describe("SynopticBreadcrumbs Component", () => {
     const links = screen.getAllByRole("link");
     expect(links.length).toBe(3);
     expect(links[0]).toHaveAttribute("href", "/synoptic/BL02/Level1");
-    expect(links[1]).toHaveAttribute("href", "/synoptic/BL02/Level1+Level2");
+    expect(links[1]).toHaveAttribute(
+      "href",
+      `/synoptic/BL02/Level1${EXPECTED_SEPARATOR}Level2`
+    );
     expect(links[2]).toHaveAttribute(
       "href",
-      "/synoptic/BL02/Level1+Level2+Level3"
+      `/synoptic/BL02/Level1${EXPECTED_SEPARATOR}Level2${EXPECTED_SEPARATOR}Level3`
     );
   });
 
@@ -169,7 +190,12 @@ describe("SynopticBreadcrumbs Component", () => {
   });
 
   it("renders NavigateNextIcon as separator", () => {
-    renderComponent(createMockState("Area1+Area2+Area3", "BL01"));
+    renderComponent(
+      createMockState(
+        `Area1${EXPECTED_SEPARATOR}Area2${EXPECTED_SEPARATOR}Area3`,
+        "BL01"
+      )
+    );
 
     const separators = document.querySelectorAll("svg");
     expect(separators.length).toBe(2);

--- a/src/tests/parser.test.ts
+++ b/src/tests/parser.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../utils/parser";
 import { FileIDs } from "../store";
 
+const SCREEN_SEPARATOR = "/";
+
 /**
  * The next few lines are mocking global fetch. This is necessary since
  * vitest runs in the "jsdom" browser environment in order to render components
@@ -124,13 +126,15 @@ describe("RecursiveTreeViewBuilder()", (): void => {
     );
 
     const guid = Object.keys(fileMap).find(
-      key => fileMap[key].urlId === "top+middle1+bottom"
+      key =>
+        fileMap[key].urlId ===
+        `top${SCREEN_SEPARATOR}middle1${SCREEN_SEPARATOR}bottom`
     );
     const guidMiddle1 = Object.keys(fileMap).find(
-      key => fileMap[key].urlId === "top+middle1"
+      key => fileMap[key].urlId === `top${SCREEN_SEPARATOR}middle1`
     );
     const guidMiddle2 = Object.keys(fileMap).find(
-      key => fileMap[key].urlId === "top+middle2"
+      key => fileMap[key].urlId === `top${SCREEN_SEPARATOR}middle2`
     );
 
     expect(guid).not.toBeUndefined();
@@ -196,7 +200,7 @@ describe("RecursiveTreeViewBuilder()", (): void => {
     );
     expect(treeViewItems.length).toEqual(1);
     const guid = Object.keys(fileMap).find(
-      key => fileMap[key].urlId === "top+middle1"
+      key => fileMap[key].urlId === `top${SCREEN_SEPARATOR}middle1`
     );
 
     expect(guid).not.toBeUndefined();
@@ -244,12 +248,12 @@ describe("RecursiveTreeViewBuilder()", (): void => {
     );
 
     const expectedUrlIds = [
-      "top+middle1",
-      "top+path0__index",
-      "top+middle1+path1__index",
-      "top+middle1+path2__index",
-      "top+middle1+index",
-      "top+middle1+not_index"
+      `top${SCREEN_SEPARATOR}middle1`,
+      `top${SCREEN_SEPARATOR}path0__index`,
+      `top${SCREEN_SEPARATOR}middle1${SCREEN_SEPARATOR}path1__index`,
+      `top${SCREEN_SEPARATOR}middle1${SCREEN_SEPARATOR}path2__index`,
+      `top${SCREEN_SEPARATOR}middle1${SCREEN_SEPARATOR}index`,
+      `top${SCREEN_SEPARATOR}middle1${SCREEN_SEPARATOR}not_index`
     ];
     const actualUrlIds = Object.values(fileMap).map(x => x.urlId);
 
@@ -296,12 +300,12 @@ describe("RecursiveTreeViewBuilder()", (): void => {
     );
 
     const expectedUrlIds = [
-      "Top Screen+Index",
-      "Top Screen+Middle Screen",
-      "Top Screen+Middle Screen+Index 1",
-      "Top Screen+Middle Screen+Index 2",
-      "Top Screen+Middle Screen+Index 3",
-      "Top Screen+Middle Screen+Not Index"
+      `Top Screen${SCREEN_SEPARATOR}Index`,
+      `Top Screen${SCREEN_SEPARATOR}Middle Screen`,
+      `Top Screen${SCREEN_SEPARATOR}Middle Screen${SCREEN_SEPARATOR}Index 1`,
+      `Top Screen${SCREEN_SEPARATOR}Middle Screen${SCREEN_SEPARATOR}Index 2`,
+      `Top Screen${SCREEN_SEPARATOR}Middle Screen${SCREEN_SEPARATOR}Index 3`,
+      `Top Screen${SCREEN_SEPARATOR}Middle Screen${SCREEN_SEPARATOR}Not Index`
     ];
     const actualUrlIds = Object.values(fileMap).map(x => x.urlId);
 

--- a/src/tests/parser.test.ts
+++ b/src/tests/parser.test.ts
@@ -3,7 +3,6 @@ import {
   parseScreenTree,
   RecursiveTreeViewBuilder,
   RecursiveAppendDuplicateFileMacros,
-  buildUrlId,
   selectFileMetadataByFilePathAndMacros
 } from "../utils/parser";
 import { FileIDs } from "../store";
@@ -438,33 +437,6 @@ describe("RecursiveAppendDuplicateFileMacros()", (): void => {
       macroHash => "Another" in macroHash
     );
     expect(aMacros).toEqual({ Another: "AnotherFilesMacros" });
-  });
-});
-
-describe("buildUrlId()", (): void => {
-  it("uses the file name if no display name", (): void => {
-    const { urlId, fileLabel } = buildUrlId("testing.bob", "", undefined);
-
-    expect(urlId).toBe("testing");
-    expect(fileLabel).toBe("testing");
-  });
-
-  it("uses display name as url id", (): void => {
-    const { urlId, fileLabel } = buildUrlId("testing.bob", "", "My File");
-
-    expect(urlId).toBe("My File");
-    expect(fileLabel).toBe("My File");
-  });
-
-  it("correctly attaches a prefix", (): void => {
-    const { urlId, fileLabel } = buildUrlId(
-      "testing.bob",
-      "First File",
-      "My File"
-    );
-
-    expect(urlId).toBe("First File+My File");
-    expect(fileLabel).toBe("My File");
   });
 });
 

--- a/src/tests/routes/SynopticPage.test.tsx
+++ b/src/tests/routes/SynopticPage.test.tsx
@@ -11,7 +11,7 @@ import {
   FileContextType,
   FileDescription
 } from "@diamondlightsource/cs-web-lib";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import * as parser from "../../utils/parser";
 import * as csWebLibActions from "../../utils/csWebLibActions";
 import {

--- a/src/tests/screenUrlIdUtils.test.ts
+++ b/src/tests/screenUrlIdUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-    buildSynopticScreenPath,
+  buildSynopticScreenPath,
   buildUrlId,
   extractAncestorScreens,
   extractDisplayNameFromScreenUrlId,
@@ -211,72 +211,71 @@ describe("extractDisplayNameFromScreenUrlId", () => {
   });
 });
 
-
-describe('parseScreenUrlId', () => {
-  it('returns a single segment when there is only one screen', () => {
-    const input = 'Home';
+describe("parseScreenUrlId", () => {
+  it("returns a single segment when there is only one screen", () => {
+    const input = "Home";
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home']);
+    expect(result).toEqual(["Home"]);
   });
 
   it('splits multiple segments by "+" and removes empties', () => {
     const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}Profile`;
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home', 'Settings', 'Profile']);
+    expect(result).toEqual(["Home", "Settings", "Profile"]);
   });
 
-  it('returns an empty array for an empty string', () => {
-    const input = '';
+  it("returns an empty array for an empty string", () => {
+    const input = "";
     const result = parseScreenUrlId(input);
 
     expect(result).toEqual([]);
   });
 
-  it('removes leading empty segments (leading separator)', () => {
+  it("removes leading empty segments (leading separator)", () => {
     const input = `${EXPECTED_SEPARATOR}Home${EXPECTED_SEPARATOR}Settings`;
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home', 'Settings']);
+    expect(result).toEqual(["Home", "Settings"]);
   });
 
-  it('removes trailing empty segments (trailing separator)', () => {
+  it("removes trailing empty segments (trailing separator)", () => {
     const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}`;
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home', 'Settings']);
+    expect(result).toEqual(["Home", "Settings"]);
   });
 
-  it('removes empty segments from consecutive separators', () => {
+  it("removes empty segments from consecutive separators", () => {
     const input = `Home${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Profile`;
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home', 'Settings', 'Profile']);
+    expect(result).toEqual(["Home", "Settings", "Profile"]);
   });
 
-  it('returns empty array when the input is only separators', () => {
+  it("returns empty array when the input is only separators", () => {
     const input = `${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}`;
     const result = parseScreenUrlId(input);
 
     expect(result).toEqual([]);
   });
 
-  it('preserves spaces and special characters (no trimming performed)', () => {
+  it("preserves spaces and special characters (no trimming performed)", () => {
     const input = `Home${EXPECTED_SEPARATOR}User Settings${EXPECTED_SEPARATOR}Billing/Invoices`;
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home', 'User Settings', 'Billing/Invoices']);
+    expect(result).toEqual(["Home", "User Settings", "Billing/Invoices"]);
   });
 
-  it('does not include whitespace-only segments', () => {
+  it("does not include whitespace-only segments", () => {
     const input = `Home${EXPECTED_SEPARATOR}   ${EXPECTED_SEPARATOR}Settings`;
     const result = parseScreenUrlId(input);
 
-    expect(result).toEqual(['Home', 'Settings']);
+    expect(result).toEqual(["Home", "Settings"]);
   });
 
-  it('does not mutate the input string', () => {
+  it("does not mutate the input string", () => {
     const input = `A${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}C`;
     const before = input;
 
@@ -285,31 +284,34 @@ describe('parseScreenUrlId', () => {
     expect(input).toBe(before);
   });
 
-  it('returns the correct length matching non-empty segments only', () => {
+  it("returns the correct length matching non-empty segments only", () => {
     const input = `A${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}C${EXPECTED_SEPARATOR}`;
     const result = parseScreenUrlId(input);
 
     expect(result).toHaveLength(3);
-    expect(result).toEqual(['A', 'B', 'C']);
+    expect(result).toEqual(["A", "B", "C"]);
   });
 });
 
-describe('buildSynopticScreenPath', () => {
-  it('builds the correct synoptic path for valid inputs', () => {
-    const result = buildSynopticScreenPath('BL01', `Home${EXPECTED_SEPARATOR}Settings`);
+describe("buildSynopticScreenPath", () => {
+  it("builds the correct synoptic path for valid inputs", () => {
+    const result = buildSynopticScreenPath(
+      "BL01",
+      `Home${EXPECTED_SEPARATOR}Settings`
+    );
 
     expect(result).toBe(`/synoptic/BL01/Home${EXPECTED_SEPARATOR}Settings`);
   });
 
-  it('works with single-segment screenUrlId', () => {
-    const result = buildSynopticScreenPath('BL02', 'Overview');
+  it("works with single-segment screenUrlId", () => {
+    const result = buildSynopticScreenPath("BL02", "Overview");
 
-    expect(result).toBe('/synoptic/BL02/Overview');
+    expect(result).toBe("/synoptic/BL02/Overview");
   });
 
-  it('preserves special characters and separators in screenUrlId', () => {
+  it("preserves special characters and separators in screenUrlId", () => {
     const result = buildSynopticScreenPath(
-      'BL-α',
+      "BL-α",
       `User Settings${EXPECTED_SEPARATOR}Billing/Invoices`
     );
 
@@ -318,27 +320,27 @@ describe('buildSynopticScreenPath', () => {
     );
   });
 
-  it('handles empty screenUrlId', () => {
-    const result = buildSynopticScreenPath('BL03', '');
+  it("handles empty screenUrlId", () => {
+    const result = buildSynopticScreenPath("BL03", "");
 
-    expect(result).toBe('/synoptic/BL03/');
+    expect(result).toBe("/synoptic/BL03/");
   });
 
-  it('handles empty beamline', () => {
-    const result = buildSynopticScreenPath('', 'Home');
+  it("handles empty beamline", () => {
+    const result = buildSynopticScreenPath("", "Home");
 
-    expect(result).toBe('/synoptic//Home');
+    expect(result).toBe("/synoptic//Home");
   });
 
-  it('returns a path starting with a leading slash', () => {
-    const result = buildSynopticScreenPath('BL04', 'Dashboard');
+  it("returns a path starting with a leading slash", () => {
+    const result = buildSynopticScreenPath("BL04", "Dashboard");
 
-    expect(result.startsWith('/')).toBe(true);
+    expect(result.startsWith("/")).toBe(true);
   });
 
-  it('does not mutate input arguments', () => {
-    const beamline = 'BL05';
-    const screenUrlId = 'A${EXPECTED_SEPARATOR}B';
+  it("does not mutate input arguments", () => {
+    const beamline = "BL05";
+    const screenUrlId = "A${EXPECTED_SEPARATOR}B";
 
     const beamlineBefore = beamline;
     const screenUrlIdBefore = screenUrlId;
@@ -350,8 +352,8 @@ describe('buildSynopticScreenPath', () => {
   });
 
   it('always places "synoptic" as the first path segment', () => {
-    const result = buildSynopticScreenPath('BL06', 'Screen');
+    const result = buildSynopticScreenPath("BL06", "Screen");
 
-    expect(result.split('/')[1]).toBe('synoptic');
+    expect(result.split("/")[1]).toBe("synoptic");
   });
 });

--- a/src/tests/screenUrlIdUtils.test.ts
+++ b/src/tests/screenUrlIdUtils.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildSynopticScreenPath,
+  buildUrlId,
+  extractAncestorScreens,
+  extractDisplayNameFromScreenUrlId,
+  parseScreenUrlId
+} from "../utils/screenUrlIdUtils";
+
+const EXPECTED_SEPARATOR = "+";
+
+describe("buildUrlId()", (): void => {
+  it("uses the file name if no display name", (): void => {
+    const { urlId, fileLabel } = buildUrlId("testing.bob", "", undefined);
+
+    expect(urlId).toBe("testing");
+    expect(fileLabel).toBe("testing");
+  });
+
+  it("uses display name as url id", (): void => {
+    const { urlId, fileLabel } = buildUrlId("testing.bob", "", "My File");
+
+    expect(urlId).toBe("My File");
+    expect(fileLabel).toBe("My File");
+  });
+
+  it("correctly attaches a prefix", (): void => {
+    const { urlId, fileLabel } = buildUrlId(
+      "testing.bob",
+      "First File",
+      "My File"
+    );
+
+    expect(urlId).toBe(`First File${EXPECTED_SEPARATOR}My File`);
+    expect(fileLabel).toBe("My File");
+  });
+});
+
+describe("extractAncestorScreens", () => {
+  it("returns single ancestor when there is only one segment", () => {
+    const input = "Home";
+    const result = extractAncestorScreens(input);
+
+    expect(result).toEqual([{ displayName: "Home", path: "Home" }]);
+  });
+
+  it("builds cumulative paths for multiple segments", () => {
+    const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}Profile`;
+    const result = extractAncestorScreens(input);
+
+    expect(result).toEqual([
+      { displayName: "Home", path: "Home" },
+      { displayName: "Settings", path: `Home${EXPECTED_SEPARATOR}Settings` },
+      {
+        displayName: "Profile",
+        path: `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}Profile`
+      }
+    ]);
+  });
+
+  it("handles empty string input (returns empty array)", () => {
+    const input = "";
+    const result = extractAncestorScreens(input);
+
+    expect(result).toEqual([]);
+  });
+
+  it("removes empty segments when there are consecutive separators", () => {
+    const input = `Home${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Profile`;
+    const result = extractAncestorScreens(input);
+
+    expect(result).toEqual([
+      { displayName: "Home", path: "Home" },
+      { displayName: "Settings", path: `Home${EXPECTED_SEPARATOR}Settings` },
+      {
+        displayName: "Profile",
+        path: `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}Profile`
+      }
+    ]);
+  });
+
+  it("handles leading separator (no leading empty segment)", () => {
+    const input = `${EXPECTED_SEPARATOR}Home${EXPECTED_SEPARATOR}Settings`;
+    const result = extractAncestorScreens(input);
+
+    expect(result).toEqual([
+      { displayName: "Home", path: "Home" },
+      { displayName: "Settings", path: `Home${EXPECTED_SEPARATOR}Settings` }
+    ]);
+  });
+
+  it("handles trailing separator (no trailing empty segment)", () => {
+    const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}`;
+    const result = extractAncestorScreens(input);
+
+    // Split: ['Home', 'Settings', '']
+    expect(result).toEqual([
+      { displayName: "Home", path: "Home" },
+      { displayName: "Settings", path: `Home${EXPECTED_SEPARATOR}Settings` }
+    ]);
+  });
+
+  it("works with names containing special characters and spaces", () => {
+    const input = `Home${EXPECTED_SEPARATOR}User Settings${EXPECTED_SEPARATOR}Billing/Invoices`;
+    const result = extractAncestorScreens(input);
+
+    expect(result).toEqual([
+      { displayName: "Home", path: "Home" },
+      {
+        displayName: "User Settings",
+        path: `Home${EXPECTED_SEPARATOR}User Settings`
+      },
+      {
+        displayName: "Billing/Invoices",
+        path: `Home${EXPECTED_SEPARATOR}User Settings${EXPECTED_SEPARATOR}Billing/Invoices`
+      }
+    ]);
+  });
+
+  it("does not mutate the input string", () => {
+    const input = `A${EXPECTED_SEPARATOR}B`;
+    const before = input;
+    extractAncestorScreens(input);
+    expect(input).toBe(before);
+  });
+
+  it("returns an array with correct length equal to number of segments", () => {
+    const input = `A${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}C${EXPECTED_SEPARATOR}D`;
+    const result = extractAncestorScreens(input);
+    expect(result).toHaveLength(4);
+  });
+
+  it("each path is the join of segments up to current index", () => {
+    const input = `A${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}C`;
+    const result = extractAncestorScreens(input);
+
+    const expectedPaths = [
+      "A",
+      `A${EXPECTED_SEPARATOR}B`,
+      `A${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}C`
+    ];
+    expect(result.map(r => r.path)).toEqual(expectedPaths);
+    expect(result.map(r => r.displayName)).toEqual(["A", "B", "C"]);
+  });
+});
+
+describe("extractDisplayNameFromScreenUrlId", () => {
+  it("returns the display name when there is only one segment", () => {
+    const input = "Home";
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("Home");
+  });
+
+  it("returns the last segment when multiple segments are present", () => {
+    const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}Profile`;
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("Profile");
+  });
+
+  it("returns an empty string when input is an empty string", () => {
+    const input = "";
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("");
+  });
+
+  it("returns an last non-empty segment string when the input ends with a separator", () => {
+    const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}`;
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("Settings");
+  });
+
+  it("returns an empty string when the input is only a separator", () => {
+    const input = EXPECTED_SEPARATOR;
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("");
+  });
+
+  it("handles consecutive separators by returning the last segment", () => {
+    const input = `Home${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Profile`;
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("Profile");
+  });
+
+  it("handles leading separator by returning the last valid segment", () => {
+    const input = `${EXPECTED_SEPARATOR}Home${EXPECTED_SEPARATOR}Settings`;
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("Settings");
+  });
+
+  it("preserves spaces and special characters in the display name", () => {
+    const input = `Home${EXPECTED_SEPARATOR}User Settings${EXPECTED_SEPARATOR}Billing/Invoices`;
+    const result = extractDisplayNameFromScreenUrlId(input);
+
+    expect(result).toBe("Billing/Invoices");
+  });
+
+  it("does not mutate the input string", () => {
+    const input = "A${EXPECTED_SEPARATOR}B";
+    const before = input;
+
+    extractDisplayNameFromScreenUrlId(input);
+
+    expect(input).toBe(before);
+  });
+});
+
+
+describe('parseScreenUrlId', () => {
+  it('returns a single segment when there is only one screen', () => {
+    const input = 'Home';
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home']);
+  });
+
+  it('splits multiple segments by "+" and removes empties', () => {
+    const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}Profile`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home', 'Settings', 'Profile']);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    const input = '';
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual([]);
+  });
+
+  it('removes leading empty segments (leading separator)', () => {
+    const input = `${EXPECTED_SEPARATOR}Home${EXPECTED_SEPARATOR}Settings`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home', 'Settings']);
+  });
+
+  it('removes trailing empty segments (trailing separator)', () => {
+    const input = `Home${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home', 'Settings']);
+  });
+
+  it('removes empty segments from consecutive separators', () => {
+    const input = `Home${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Settings${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}Profile`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home', 'Settings', 'Profile']);
+  });
+
+  it('returns empty array when the input is only separators', () => {
+    const input = `${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual([]);
+  });
+
+  it('preserves spaces and special characters (no trimming performed)', () => {
+    const input = `Home${EXPECTED_SEPARATOR}User Settings${EXPECTED_SEPARATOR}Billing/Invoices`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home', 'User Settings', 'Billing/Invoices']);
+  });
+
+  it('does not include whitespace-only segments', () => {
+    const input = `Home${EXPECTED_SEPARATOR}   ${EXPECTED_SEPARATOR}Settings`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toEqual(['Home', 'Settings']);
+  });
+
+  it('does not mutate the input string', () => {
+    const input = `A${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}C`;
+    const before = input;
+
+    parseScreenUrlId(input);
+
+    expect(input).toBe(before);
+  });
+
+  it('returns the correct length matching non-empty segments only', () => {
+    const input = `A${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}B${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}${EXPECTED_SEPARATOR}C${EXPECTED_SEPARATOR}`;
+    const result = parseScreenUrlId(input);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(['A', 'B', 'C']);
+  });
+});
+
+describe('buildSynopticScreenPath', () => {
+  it('builds the correct synoptic path for valid inputs', () => {
+    const result = buildSynopticScreenPath('BL01', `Home${EXPECTED_SEPARATOR}Settings`);
+
+    expect(result).toBe(`/synoptic/BL01/Home${EXPECTED_SEPARATOR}Settings`);
+  });
+
+  it('works with single-segment screenUrlId', () => {
+    const result = buildSynopticScreenPath('BL02', 'Overview');
+
+    expect(result).toBe('/synoptic/BL02/Overview');
+  });
+
+  it('preserves special characters and separators in screenUrlId', () => {
+    const result = buildSynopticScreenPath(
+      'BL-α',
+      `User Settings${EXPECTED_SEPARATOR}Billing/Invoices`
+    );
+
+    expect(result).toBe(
+      `/synoptic/BL-α/User Settings${EXPECTED_SEPARATOR}Billing/Invoices`
+    );
+  });
+
+  it('handles empty screenUrlId', () => {
+    const result = buildSynopticScreenPath('BL03', '');
+
+    expect(result).toBe('/synoptic/BL03/');
+  });
+
+  it('handles empty beamline', () => {
+    const result = buildSynopticScreenPath('', 'Home');
+
+    expect(result).toBe('/synoptic//Home');
+  });
+
+  it('returns a path starting with a leading slash', () => {
+    const result = buildSynopticScreenPath('BL04', 'Dashboard');
+
+    expect(result.startsWith('/')).toBe(true);
+  });
+
+  it('does not mutate input arguments', () => {
+    const beamline = 'BL05';
+    const screenUrlId = 'A${EXPECTED_SEPARATOR}B';
+
+    const beamlineBefore = beamline;
+    const screenUrlIdBefore = screenUrlId;
+
+    buildSynopticScreenPath(beamline, screenUrlId);
+
+    expect(beamline).toBe(beamlineBefore);
+    expect(screenUrlId).toBe(screenUrlIdBefore);
+  });
+
+  it('always places "synoptic" as the first path segment', () => {
+    const result = buildSynopticScreenPath('BL06', 'Screen');
+
+    expect(result.split('/')[1]).toBe('synoptic');
+  });
+});

--- a/src/tests/screenUrlIdUtils.test.ts
+++ b/src/tests/screenUrlIdUtils.test.ts
@@ -359,72 +359,72 @@ describe("buildSynopticScreenPath", () => {
   });
 });
 
-describe('parseFullSynopticPath', () => {
-  it('should correctly parse a valid synoptic path', () => {
-    const path = '/synoptic/bl01/synoptic-screen';
+describe("parseFullSynopticPath", () => {
+  it("should correctly parse a valid synoptic path", () => {
+    const path = "/synoptic/bl01/synoptic-screen";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toEqual({
-      beamline: 'bl01',
-      screenUrlId: 'synoptic-screen'
+      beamline: "bl01",
+      screenUrlId: "synoptic-screen"
     });
   });
 
-  it('should correctly parse a path with complex screenUrlId containing slashes', () => {
-    const path = '/synoptic/bl02/controls/main/dashboard';
+  it("should correctly parse a path with complex screenUrlId containing slashes", () => {
+    const path = "/synoptic/bl02/controls/main/dashboard";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toEqual({
-      beamline: 'bl02',
-      screenUrlId: 'controls/main/dashboard'
+      beamline: "bl02",
+      screenUrlId: "controls/main/dashboard"
     });
   });
 
-  it('should correctly parse a path with special characters in beamline and screenUrlId', () => {
-    const path = '/synoptic/bl-03_test/screen_01/dash-board';
+  it("should correctly parse a path with special characters in beamline and screenUrlId", () => {
+    const path = "/synoptic/bl-03_test/screen_01/dash-board";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toEqual({
-      beamline: 'bl-03_test',
-      screenUrlId: 'screen_01/dash-board'
+      beamline: "bl-03_test",
+      screenUrlId: "screen_01/dash-board"
     });
   });
 
-  it('should return null for a path not starting with /synoptic/', () => {
-    const path = '/editor/bl01/main';
+  it("should return null for a path not starting with /synoptic/", () => {
+    const path = "/editor/bl01/main";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toBeNull();
   });
 
-  it('should return null for a path with incorrect format', () => {
-    const path = '/synoptic/';
+  it("should return null for a path with incorrect format", () => {
+    const path = "/synoptic/";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toBeNull();
   });
 
-  it('should return null for an empty path', () => {
-    const path = '';
+  it("should return null for an empty path", () => {
+    const path = "";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toBeNull();
   });
 
-  it('should return null for a path with empty beamline', () => {
-    const path = '/synoptic//screen';
+  it("should return null for a path with empty beamline", () => {
+    const path = "/synoptic//screen";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toBeNull();
   });
 
-  it('should handle a path with empty screenUrlId correctly', () => {
-    const path = '/synoptic/bl04/';
+  it("should handle a path with empty screenUrlId correctly", () => {
+    const path = "/synoptic/bl04/";
     const result = parseFullSynopticPath(path);
-    
+
     expect(result).toEqual({
-      beamline: 'bl04',
-      screenUrlId: ''
+      beamline: "bl04",
+      screenUrlId: ""
     });
   });
 });

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -4,6 +4,7 @@ import {
   CsWebLibHttpResponseError,
   httpRequest
 } from "@diamondlightsource/cs-web-lib";
+import { buildUrlId } from "./screenUrlIdUtils";
 
 /**
  * Select a file metadata record from a set of records, using the file path and the macro set
@@ -189,29 +190,4 @@ export const RecursiveAppendDuplicateFileMacros = (
 
     RecursiveAppendDuplicateFileMacros(sibling?.children, fileMap);
   }
-};
-
-/**
- * Builds the ID to display in the URL, based on the file name
- * and/or a given display name
- * @param filepath string path of bob file
- * @param idPrefix string prefix of all parent file IDs
- * @param displayName string alternate name of file to display
- * @returns string ID of url, label to display for current file
- */
-export const buildUrlId = (
-  filepath: string,
-  idPrefix: string,
-  displayName?: string
-) => {
-  const splitFilePath = filepath.split(".bob")[0].split("/");
-  let fileLabel: string = displayName || splitFilePath.pop()!;
-  if (fileLabel === "index") {
-    const parentDir = splitFilePath.pop();
-    if (parentDir) {
-      fileLabel = `${parentDir}__${fileLabel}`;
-    }
-  }
-  const urlId = `${idPrefix}${idPrefix === "" ? "" : "+"}${fileLabel}`;
-  return { urlId, fileLabel };
 };

--- a/src/utils/screenUrlIdUtils.ts
+++ b/src/utils/screenUrlIdUtils.ts
@@ -1,4 +1,4 @@
-const SCREEN_SEPARATOR = "+";
+const SCREEN_SEPARATOR = "/";
 
 /**
  * Builds the ID to display in the URL, based on the file name
@@ -24,6 +24,14 @@ export const buildUrlId = (
   const urlId = `${idPrefix}${idPrefix === "" ? "" : SCREEN_SEPARATOR}${fileLabel}`;
   return { urlId, fileLabel };
 };
+
+export const parseFullSynopticPath = (path: string): { beamline: string; screenUrlId: string } | null => {
+  const m = path.match(/^\/synoptic\/([^/]+)\/(.*)$/);
+  if (!m) return null;
+
+  const [, beamline, screenUrlId] = m;
+  return { beamline, screenUrlId };
+}
 
 export const parseScreenUrlId = (screenUrlId: string): string[] =>
   screenUrlId

--- a/src/utils/screenUrlIdUtils.ts
+++ b/src/utils/screenUrlIdUtils.ts
@@ -25,13 +25,15 @@ export const buildUrlId = (
   return { urlId, fileLabel };
 };
 
-export const parseFullSynopticPath = (path: string): { beamline: string; screenUrlId: string } | null => {
+export const parseFullSynopticPath = (
+  path: string
+): { beamline: string; screenUrlId: string } | null => {
   const m = path.match(/^\/synoptic\/([^/]+)\/(.*)$/);
   if (!m) return null;
 
   const [, beamline, screenUrlId] = m;
   return { beamline, screenUrlId };
-}
+};
 
 export const parseScreenUrlId = (screenUrlId: string): string[] =>
   screenUrlId

--- a/src/utils/screenUrlIdUtils.ts
+++ b/src/utils/screenUrlIdUtils.ts
@@ -1,0 +1,55 @@
+const SCREEN_SEPARATOR = "+";
+
+/**
+ * Builds the ID to display in the URL, based on the file name
+ * and/or a given display name
+ * @param filepath string path of bob file
+ * @param idPrefix string prefix of all parent file IDs
+ * @param displayName string alternate name of file to display
+ * @returns string ID of url, label to display for current file
+ */
+export const buildUrlId = (
+  filepath: string,
+  idPrefix: string,
+  displayName?: string
+) => {
+  const splitFilePath = filepath.split(".bob")[0].split("/");
+  let fileLabel: string = displayName || splitFilePath.pop()!;
+  if (fileLabel === "index") {
+    const parentDir = splitFilePath.pop();
+    if (parentDir) {
+      fileLabel = `${parentDir}__${fileLabel}`;
+    }
+  }
+  const urlId = `${idPrefix}${idPrefix === "" ? "" : SCREEN_SEPARATOR}${fileLabel}`;
+  return { urlId, fileLabel };
+};
+
+export const parseScreenUrlId = (screenUrlId: string): string[] =>
+  screenUrlId
+    ?.split(SCREEN_SEPARATOR)
+    ?.filter(screen => !!screen && screen.trim() != "");
+
+export const extractAncestorScreens = (
+  screenUrlId: string
+): { displayName: string; path: string }[] => {
+  const ancestorScreenDisplayNames = parseScreenUrlId(screenUrlId);
+  const screenAncestry = ancestorScreenDisplayNames.map((screen, index) => {
+    return {
+      displayName: screen,
+      path: ancestorScreenDisplayNames
+        .slice(0, index + 1)
+        .join(SCREEN_SEPARATOR)
+    };
+  });
+
+  return screenAncestry;
+};
+
+export const extractDisplayNameFromScreenUrlId = (screenUrlId: string) =>
+  parseScreenUrlId(screenUrlId).pop() || "";
+
+export const buildSynopticScreenPath = (
+  beamline: string,
+  screenUrlId: string
+): string => `/synoptic/${beamline}/${screenUrlId}`;


### PR DESCRIPTION
- Upgrade to React Router 7.
- Switch to the modern data router style of react router
- Switch the screen hierarchy separator from + to / in the URL.
- Collect all the methods that handle URL path processing in a single utilities module to enable consistent reuse.