### PR TITLE
added resizing functionality to drawer, and drawer variables to menu …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daedalus",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "dependencies": {
         "@diamondlightsource/cs-web-lib": "^0.9.14",
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 interface AppBarProps extends MuiAppBarProps {
   fullscreen: number;
   open?: boolean;
+  drawerWidth?: number;
 }
 
 export const StyledAppBar = styled(MuiAppBar, {
@@ -50,10 +51,17 @@ export const StyledAppBar = styled(MuiAppBar, {
 const DLSAppBar = (props: {
   fullScreen: boolean;
   open?: boolean;
+  drawerWidth?: number;
+  isResizingDrawer?: boolean;
   children?: React.ReactNode;
 }) => {
   const navigate = useNavigate();
-  const { fullScreen, open } = props;
+  const {
+    fullScreen,
+    open,
+    drawerWidth = DRAWER_WIDTH,
+    isResizingDrawer
+  } = props;
   const handleOpenSettings = () => {
     console.log("TO DO - create settings modal");
   };
@@ -65,7 +73,26 @@ const DLSAppBar = (props: {
         position="absolute"
         open={open}
         fullscreen={fullScreen ? 1 : 0}
-        sx={{ height: APP_BAR_HEIGHT }}
+        sx={{
+          height: APP_BAR_HEIGHT,
+          ...(open &&
+            !fullScreen && {
+              marginLeft: `${drawerWidth}px`,
+              width: `calc(100% - ${drawerWidth}px)`,
+              transition: isResizingDrawer
+                ? "none"
+                : theme =>
+                    theme.transitions.create(["width", "margin"], {
+                      easing: theme.transitions.easing.sharp,
+                      duration: theme.transitions.duration.enteringScreen
+                    })
+            }),
+          ...(!open &&
+            !fullScreen && {
+              marginLeft: theme => `calc(${theme.spacing(7)} + 1px)`,
+              width: theme => `calc(100% - ${theme.spacing(7)} - 8px)`
+            })
+        }}
       >
         <Toolbar>
           <Box

--- a/src/components/ScreenDisplay.tsx
+++ b/src/components/ScreenDisplay.tsx
@@ -23,32 +23,25 @@ import { selectFileMetadataByFilePathAndMacros } from "../utils/parser";
 
 interface PaperProps extends MuiPaperProps {
   open?: boolean;
+  drawerWidth?: number;
 }
 
 const Paper = styled(MuiPaper, {
-  shouldForwardProp: prop => prop !== "open"
-})<PaperProps>(({ theme }) => ({
+  shouldForwardProp: prop => prop !== "open" && prop !== "drawerWidth"
+})<PaperProps>(({ theme, open, drawerWidth = DRAWER_WIDTH }) => ({
   height: `calc(${useWindowHeight()}px - ${APP_BAR_HEIGHT}px - 10px)`,
   margin: `calc(${APP_BAR_HEIGHT}px + 5px) 5px 5px 5px`,
-  variants: [
-    {
-      props: ({ open }) => open,
-      style: {
-        width: `calc(${useWindowWidth()}px - 10px - ${DRAWER_WIDTH}px)`
-      }
-    },
-    {
-      props: ({ open }) => !open,
-      style: {
-        width: `calc(${useWindowWidth()}px - 10px - ${theme.spacing(7)} - 8px)`
-      }
-    }
-  ]
+  ...(open && {
+    width: `calc(${useWindowWidth()}px - 10px - ${drawerWidth}px)`
+  }),
+  ...(!open && {
+    width: `calc(${useWindowWidth()}px - 10px - ${theme.spacing(7)} - 8px)`
+  })
 }));
 
 export default function ScreenDisplay() {
   const { state } = useContext(BeamlineTreeStateContext);
-  const { menuOpen } = useContext(MenuContext);
+  const { menuOpen, drawerWidth } = useContext(MenuContext);
   const fileContext = useContext(FileContext);
   const navigate = useNavigate();
   const location = useLocation();
@@ -84,7 +77,7 @@ export default function ScreenDisplay() {
   }, [fileContext.pageState.main]);
 
   return (
-    <Paper component="main" open={menuOpen}>
+    <Paper component="main" open={menuOpen} drawerWidth={drawerWidth}>
       <Box>
         <Box>
           {state.currentBeamline && state.currentScreenUrlId ? (

--- a/src/routes/SynopticPage.tsx
+++ b/src/routes/SynopticPage.tsx
@@ -34,6 +34,7 @@ import {
   executeOpenPageActionWithUrlId,
   executeOpenPageAction
 } from "../utils/csWebLibActions";
+import { DRAWER_WIDTH } from "../utils/helper";
 
 const FILE_DESCRIPTION_SEARCH_PARAMETER_NAME = "file_description";
 const MACROS_SEARCH_PARAMETER_NAME = "macros";
@@ -41,7 +42,18 @@ const MACROS_SEARCH_PARAMETER_NAME = "macros";
 export const MenuContext = createContext<{
   menuOpen: boolean;
   setMenuOpen: any;
-}>({ menuOpen: true, setMenuOpen: () => null });
+  drawerWidth: number;
+  setDrawerWidth: any;
+  isResizingDrawer: boolean;
+  setIsResizingDrawer: any;
+}>({
+  menuOpen: true,
+  setMenuOpen: () => null,
+  drawerWidth: DRAWER_WIDTH,
+  setDrawerWidth: () => null,
+  isResizingDrawer: false,
+  setIsResizingDrawer: () => null
+});
 
 export function SynopticPage() {
   const { state, dispatch } = useContext(BeamlineTreeStateContext);
@@ -49,6 +61,8 @@ export function SynopticPage() {
   const fileContext = useContext(FileContext);
   const [searchParams] = useSearchParams();
   const [menuOpen, setMenuOpen] = useState(true);
+  const [drawerWidth, setDrawerWidth] = useState(DRAWER_WIDTH);
+  const [isResizingDrawer, setIsResizingDrawer] = useState(false);
   const location = useLocation();
 
   useEffect(() => {
@@ -157,8 +171,22 @@ export function SynopticPage() {
         {state.filesLoaded ? (
           <>
             <FileContext.Provider value={updatedFileContext}>
-              <MenuContext.Provider value={{ menuOpen, setMenuOpen }}>
-                <DLSAppBar fullScreen={false} open={menuOpen}>
+              <MenuContext.Provider
+                value={{
+                  menuOpen,
+                  setMenuOpen,
+                  drawerWidth,
+                  setDrawerWidth,
+                  isResizingDrawer,
+                  setIsResizingDrawer
+                }}
+              >
+                <DLSAppBar
+                  fullScreen={false}
+                  open={menuOpen}
+                  drawerWidth={drawerWidth}
+                  isResizingDrawer={isResizingDrawer}
+                >
                   <SynopticBreadcrumbs />
                 </DLSAppBar>
                 <MiniMenuBar />

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 
 export const DRAWER_WIDTH = 300;
+export const DRAWER_MIN_WIDTH = 150;
+export const DRAWER_MAX_WIDTH = 800;
 export const TRACES_PANEL_HEIGHT = 300;
 export const APP_BAR_HEIGHT = 65;
 export const PROPERTIES_MENU_WIDTH = 350;


### PR DESCRIPTION
Added drawerWidth, setDrawerWidth, isResizingDrawer, setisResizingDrawer to context

- helper
Add drawer min and max width constants

- SynopticPage
Pass drawerWidth and isResizingDrawer to DLSAppBar so it can resize with the sidebar 

- MiniMenuBar
Add mouse event listeners to change drawer size
Disable animation when resizing with mouse
Update menubarheader so its sticky
Added extra <Box> so the rsizing bar can be grabbed when there is a scrollbar
Removed <divider/> now the top is sticky

- DLSAppBar
Added drawerwidth and isResizingDrawer to props
Use sx prop instead of variants because it wasnt updating on new render whem drawerwidth changes
Disable animation again

- ScreenDisplay
Add dynamic drawer width prop to <Paper>
Change from variants again for same reason

- MenuBarHeader
Before:
<img width="285" height="130" alt="d2_bef" src="https://github.com/user-attachments/assets/0df4775f-6843-460f-aba6-89badd5c536d" />
<img width="289" height="142" alt="d1_bef" src="https://github.com/user-attachments/assets/9bc995cf-1d35-431b-b9f5-74a046deeffb" />

After:
<img width="284" height="131" alt="d2_aft" src="https://github.com/user-attachments/assets/dce1f2da-4e05-46cf-aa56-915ba4a999e3" />
<img width="286" height="107" alt="d1_aft" src="https://github.com/user-attachments/assets/6bedc6a3-2313-45a3-8628-06576cd99ccf" />
